### PR TITLE
fix: add Stream Deck XL and missing device layouts

### DIFF
--- a/profile_manager.py
+++ b/profile_manager.py
@@ -51,8 +51,13 @@ DEFAULT_PAGE_MANIFEST = {
 }
 
 MODEL_LAYOUTS: dict[str, tuple[int, int]] = {
-    "20GBA9901": (5, 3),
-    "UI Stream Deck": (4, 2),
+    "20GBA9901": (5, 3),       # Stream Deck Original (15 keys)
+    "20GAA9901": (5, 3),       # Stream Deck MK.2 (15 keys)
+    "20GAT9902": (8, 4),       # Stream Deck XL (32 keys)
+    "20GBA9902": (8, 4),       # Stream Deck XL rev2 (32 keys)
+    "20GAI9501": (3, 2),       # Stream Deck Mini (6 keys)
+    "20GBD9901": (4, 2),       # Stream Deck Neo (8 keys + touchscreen)
+    "UI Stream Deck": (4, 2),  # Virtual Stream Deck
 }
 
 HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}$")


### PR DESCRIPTION
## Summary

- `MODEL_LAYOUTS` only contained the Original (20GBA9901) and Virtual (UI Stream Deck) models
- Any other device — including the **XL (20GAT9902)** — fell through to the 5×3 fallback in `_resolve_layout()`, making it impossible to address all 32 keys
- Added: XL (8×4), XL rev2 (8×4), MK.2 (5×3), Mini (3×2), Neo (4×2)

## Test plan

- [x] Verified on a real Stream Deck XL (20GAT9902) — layout now correctly returns `columns: 8, rows: 4`
- [x] All 32 button positions (0,0 through 7,3) are readable and writable
- [x] Verify other model IDs if hardware available

🤖 Generated with [Claude Code](https://claude.com/claude-code)