### PR TITLE
fix(profile): correct Stream Deck + XL keypad layout to 9x4

### DIFF
--- a/profile_manager.py
+++ b/profile_manager.py
@@ -65,8 +65,8 @@ DEFAULT_PAGE_MANIFEST = {
 MODEL_LAYOUTS: dict[str, dict[str, tuple[int, int]]] = {
     # Stream Deck (Original)
     "20GBA9901": {KEYPAD: (5, 3)},
-    # Stream Deck + XL (32 keys, 6 dials with 1200x100 touchstrip)
-    "20GBX9901": {KEYPAD: (8, 4), ENCODER: (6, 1)},
+    # Stream Deck + XL (36 keys, 6 dials with 1200x100 touchstrip)
+    "20GBX9901": {KEYPAD: (9, 4), ENCODER: (6, 1)},
     # Emulator used by the Elgato desktop app
     "UI Stream Deck": {KEYPAD: (4, 2)},
 }

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -382,7 +382,7 @@ def test_read_page_requires_locator(sample_profiles_v3: Path, tmp_path: Path) ->
 
 @pytest.fixture
 def sample_profiles_plus_xl(tmp_path: Path) -> Path:
-    """Profile shaped like a Stream Deck + XL: Keypad 8x4 + Encoder 6x1 on the same page."""
+    """Profile shaped like a Stream Deck + XL: Keypad 9x4 + Encoder 6x1 on the same page."""
 
     profiles_dir = tmp_path / "ProfilesV3"
     profile_dir = profiles_dir / "PLUSXL.sdProfile"
@@ -449,9 +449,9 @@ def test_read_page_returns_both_controllers(sample_profiles_plus_xl: Path, tmp_p
 
     page = manager.read_page(profile_name="Plus XL", page_index=0)
 
-    assert page["layout"] == {"columns": 8, "rows": 4}
+    assert page["layout"] == {"columns": 9, "rows": 4}
     assert page["layouts"] == {
-        "keypad": {"columns": 8, "rows": 4},
+        "keypad": {"columns": 9, "rows": 4},
         "encoder": {"columns": 6, "rows": 1},
     }
     controllers = {button["controller"] for button in page["buttons"]}


### PR DESCRIPTION
## Summary

- Empirical hardware probe on a physical Stream Deck + XL showed the device has **9 keypad columns**, not 8. Writing to `position: 7,0` left the rightmost physical column unused; `8,0` lands at the true right edge.
- `MODEL_LAYOUTS["20GBX9901"]` bumped from `KEYPAD: (8, 4)` → `(9, 4)`; comment updated from 32 → 36 keys.
- Plus XL test fixture and layout assertions updated to 9×4.

## How we confirmed

Wrote a probe page directly to the profile manifest with buttons `0..8` across the top row (col 8 colored red). On-device, the red "8" tile rendered at the rightmost physical column and "0" at the leftmost — confirming 9 columns.

## Test plan

- [x] `uv run pytest tests/` — 51 passed
- [x] `uv run ruff check .` — clean
- [ ] Visually re-verify corners on-device after this lands (write corners at `0,0 / 8,0 / 0,3 / 8,3`)

## Out of scope

Touchstrip rendering (per-encoder `TouchDisplay` feedback) is still unhandled — deferred to the upcoming dynamic-icon-URL feature pass, where it's a natural fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)