### PR TITLE
feat(touchstrip): expose $X1/$A0/$A1/$B1/$B2/$C1 encoder layouts

### DIFF
--- a/profile_manager.py
+++ b/profile_manager.py
@@ -1200,6 +1200,10 @@ class ProfileManager:
                 raise ProfileValidationError(
                     "strip_background_path is only valid for encoder/dial buttons."
                 )
+            if button.get("encoder_layout") is not None:
+                raise ProfileValidationError(
+                    "encoder_layout is only valid for encoder/dial buttons."
+                )
             if icon_path:
                 state_data["Image"] = self._copy_icon_to_page(
                     Path(icon_path).expanduser(), page_dir
@@ -1212,6 +1216,13 @@ class ProfileManager:
     def _build_action_from_fields(
         self, button: dict[str, Any], *, controller_type: str = KEYPAD
     ) -> dict[str, Any]:
+        if button.get("encoder_layout") is not None and any(
+            button.get(k) for k in ("path", "action_type", "plugin_uuid", "action_uuid")
+        ):
+            raise ProfileValidationError(
+                "encoder_layout is a convenience field for the built-in MCP dial. "
+                "Do not combine with path/action_type/plugin_uuid/action_uuid."
+            )
         action_type = button.get("action_type")
         if action_type == "next_page":
             return self._build_navigation_action(direction="next")
@@ -1295,12 +1306,31 @@ class ProfileManager:
         return ensure_mcp_plugin_installed(force=force)
 
     def _build_mcp_dial_action(self, button: dict[str, Any]) -> dict[str, Any]:
-        from streamdeck_plugin import ACTION_UUID, PLUGIN_UUID, PLUGIN_VERSION
+        from streamdeck_plugin import (
+            DEFAULT_ACTION_UUID,
+            LAYOUT_ACTION_UUIDS,
+            PLUGIN_UUID,
+            PLUGIN_VERSION,
+            SUPPORTED_ENCODER_LAYOUTS,
+        )
+
+        encoder_layout = button.get("encoder_layout")
+        if encoder_layout is not None:
+            if encoder_layout not in LAYOUT_ACTION_UUIDS:
+                raise ProfileValidationError(
+                    f"Unknown encoder_layout '{encoder_layout}'. "
+                    f"Supported: {', '.join(SUPPORTED_ENCODER_LAYOUTS)}."
+                )
+            action_uuid = LAYOUT_ACTION_UUIDS[encoder_layout]
+            name = f"MCP Dial ({encoder_layout})"
+        else:
+            action_uuid = DEFAULT_ACTION_UUID
+            name = "MCP Dial"
 
         return {
             "ActionID": str(uuid.uuid4()),
             "LinkedTitle": False,
-            "Name": "MCP Dial",
+            "Name": name,
             "Plugin": {
                 "Name": "streamdeck-mcp",
                 "UUID": PLUGIN_UUID,
@@ -1309,7 +1339,7 @@ class ProfileManager:
             "Settings": copy.deepcopy(button.get("settings", {})),
             "State": 0,
             "States": [{}],
-            "UUID": ACTION_UUID,
+            "UUID": action_uuid,
         }
 
     def _build_navigation_action(self, *, direction: str) -> dict[str, Any]:

--- a/profile_manager.py
+++ b/profile_manager.py
@@ -336,17 +336,30 @@ def ensure_mcp_plugin_installed(*, force: bool = False) -> dict[str, Any]:
     action whose plugin does not declare encoder support.
 
     Idempotent: returns ``installed=False`` when the plugin directory already
-    exists, unless ``force=True`` is passed.
+    exists at the current bundled version, unless ``force=True`` is passed.
+    Automatically upgrades when the installed manifest version is older than the
+    bundled version so that new action UUIDs (e.g. layout variants) are available.
     """
     from importlib.resources import as_file, files
 
-    from streamdeck_plugin import PLUGIN_DIR_NAME
+    from streamdeck_plugin import PLUGIN_DIR_NAME, PLUGIN_VERSION
 
     plugins_dir = get_plugins_dir()
     dst = plugins_dir / PLUGIN_DIR_NAME
 
     if dst.exists() and not force:
-        return {"installed": False, "reason": "already installed", "path": str(dst)}
+        installed_version: str | None = None
+        try:
+            installed_manifest = dst / "manifest.json"
+            installed_version = json.loads(installed_manifest.read_text(encoding="utf-8")).get(
+                "Version"
+            )
+        except Exception:
+            pass
+
+        if installed_version == PLUGIN_VERSION:
+            return {"installed": False, "reason": "already installed", "path": str(dst)}
+        # Installed version is missing or outdated — fall through to reinstall.
 
     plugins_dir.mkdir(parents=True, exist_ok=True)
     if dst.exists():
@@ -1216,7 +1229,12 @@ class ProfileManager:
     def _build_action_from_fields(
         self, button: dict[str, Any], *, controller_type: str = KEYPAD
     ) -> dict[str, Any]:
-        if button.get("encoder_layout") is not None and any(
+        encoder_layout = button.get("encoder_layout")
+        if encoder_layout is not None and controller_type != ENCODER:
+            raise ProfileValidationError(
+                "encoder_layout is only valid for encoder/dial buttons."
+            )
+        if encoder_layout is not None and any(
             button.get(k) for k in ("path", "action_type", "plugin_uuid", "action_uuid")
         ):
             raise ProfileValidationError(

--- a/profile_server.py
+++ b/profile_server.py
@@ -93,6 +93,21 @@ async def list_tools() -> list[Tool]:
                     "keypad button is an error."
                 ),
             },
+            "encoder_layout": {
+                "type": "string",
+                "enum": ["$X1", "$A0", "$A1", "$B1", "$B2", "$C1"],
+                "description": (
+                    "Encoder/dial only: built-in Elgato touchstrip layout. Omit for "
+                    "the default (no declared layout → Elgato default composition with "
+                    "full-strip background show-through). Choose a variant for plugin-"
+                    "rendered layouts: $X1 (title + centered icon), $A0 (title + full-"
+                    "width image), $A1 (title + icon + value slot), $B1 (progress bar), "
+                    "$B2 (gradient progress), $C1 (dual icon/progress rows). Selecting "
+                    "a layout forgoes strip-background show-through — the declared "
+                    "layout replaces the default composition. Do not combine with "
+                    "path/action_type/plugin_uuid/action_uuid."
+                ),
+            },
             "path": {
                 "type": "string",
                 "description": (

--- a/skills/streamdeck-profile/SKILL.md
+++ b/skills/streamdeck-profile/SKILL.md
@@ -81,8 +81,11 @@ These are the source of truth for manifest schemas, image dimensions, and touchs
 
 ### Built-in touchstrip layouts
 
+Pass `encoder_layout: "$A1"` (etc.) on an encoder button in `streamdeck_write_page` to opt into a layout. Omit `encoder_layout` for the default (Elgato default composition with full-strip background show-through). Picking a variant forgoes show-through — the declared layout replaces the default composition.
+
 | Layout | Semantics |
 |--------|-----------|
+| *(omit)* | Default: icon over `Encoder.background`, full-strip `Controllers[Encoder].Background` shows through |
 | `$X1` | Title top, icon centered |
 | `$A0` | Title top, full-width image canvas center |
 | `$A1` | Title top, icon left, text value right |
@@ -90,7 +93,9 @@ These are the source of truth for manifest schemas, image dimensions, and touchs
 | `$B2` | Title top, icon left, text + gradient progress bar |
 | `$C1` | Title top, dual icon-left/progress-right rows |
 
-Custom layouts are supported as JSON shipped with the plugin.
+Each variant is a separate action UUID in the bundled plugin (`io.github.verygoodplugins.streamdeck-mcp.dial.<x1|a0|a1|b1|b2|c1>`) with `Encoder.layout` statically declared — the only Elgato-documented, durable way to set a layout.
+
+Custom layouts (JSON shipped with the plugin) are not yet supported; deferred until a concrete layout requires it.
 
 ### Touchstrip custom art goes in the profile manifest, not `setFeedback`
 

--- a/streamdeck_plugin/__init__.py
+++ b/streamdeck_plugin/__init__.py
@@ -10,6 +10,20 @@ from importlib.resources import as_file, files
 PLUGIN_UUID = "io.github.verygoodplugins.streamdeck-mcp"
 PLUGIN_DIR_NAME = f"{PLUGIN_UUID}.sdPlugin"
 ACTION_UUID = f"{PLUGIN_UUID}.dial"
+DEFAULT_ACTION_UUID = ACTION_UUID
+
+# Layout-declaring action variants. Each UUID maps to a plugin-manifest action
+# whose `Encoder.layout` is statically set to the corresponding Elgato built-in.
+# Callers select one by passing `encoder_layout="$A1"` etc. on an encoder button.
+LAYOUT_ACTION_UUIDS: dict[str, str] = {
+    "$X1": f"{PLUGIN_UUID}.dial.x1",
+    "$A0": f"{PLUGIN_UUID}.dial.a0",
+    "$A1": f"{PLUGIN_UUID}.dial.a1",
+    "$B1": f"{PLUGIN_UUID}.dial.b1",
+    "$B2": f"{PLUGIN_UUID}.dial.b2",
+    "$C1": f"{PLUGIN_UUID}.dial.c1",
+}
+SUPPORTED_ENCODER_LAYOUTS: tuple[str, ...] = tuple(LAYOUT_ACTION_UUIDS.keys())
 
 # Read the plugin version directly from the bundled manifest so there is a
 # single source of truth — the manifest — rather than a duplicated constant.

--- a/streamdeck_plugin/io.github.verygoodplugins.streamdeck-mcp.sdPlugin/manifest.json
+++ b/streamdeck_plugin/io.github.verygoodplugins.streamdeck-mcp.sdPlugin/manifest.json
@@ -3,7 +3,7 @@
     "Author": "Very Good Plugins",
     "Description": "Renders images and titles set by the streamdeck-mcp profile writer on keypad keys and Stream Deck + touchstrip segments.",
     "URL": "https://github.com/verygoodplugins/streamdeck-mcp",
-    "Version": "0.1.0",
+    "Version": "0.2.0",
     "CodePath": "plugin.html",
     "Icon": "Images/plugin",
     "Category": "streamdeck-mcp",
@@ -24,6 +24,114 @@
             "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
             "Controllers": ["Keypad", "Encoder"],
             "Encoder": {
+                "StackColor": "#000000",
+                "TriggerDescription": {
+                    "Rotate": "",
+                    "Push": "",
+                    "Touch": ""
+                }
+            }
+        },
+        {
+            "UUID": "io.github.verygoodplugins.streamdeck-mcp.dial.x1",
+            "Name": "MCP Dial ($X1 — icon)",
+            "Tooltip": "streamdeck-mcp dial with Elgato built-in $X1 layout (title + centered icon).",
+            "Icon": "Images/action",
+            "PropertyInspectorPath": "",
+            "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
+            "Controllers": ["Encoder"],
+            "Encoder": {
+                "layout": "$X1",
+                "StackColor": "#000000",
+                "TriggerDescription": {
+                    "Rotate": "",
+                    "Push": "",
+                    "Touch": ""
+                }
+            }
+        },
+        {
+            "UUID": "io.github.verygoodplugins.streamdeck-mcp.dial.a0",
+            "Name": "MCP Dial ($A0 — full image)",
+            "Tooltip": "streamdeck-mcp dial with Elgato built-in $A0 layout (title + full-width image canvas).",
+            "Icon": "Images/action",
+            "PropertyInspectorPath": "",
+            "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
+            "Controllers": ["Encoder"],
+            "Encoder": {
+                "layout": "$A0",
+                "StackColor": "#000000",
+                "TriggerDescription": {
+                    "Rotate": "",
+                    "Push": "",
+                    "Touch": ""
+                }
+            }
+        },
+        {
+            "UUID": "io.github.verygoodplugins.streamdeck-mcp.dial.a1",
+            "Name": "MCP Dial ($A1 — icon + value)",
+            "Tooltip": "streamdeck-mcp dial with Elgato built-in $A1 layout (title + icon + value slot).",
+            "Icon": "Images/action",
+            "PropertyInspectorPath": "",
+            "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
+            "Controllers": ["Encoder"],
+            "Encoder": {
+                "layout": "$A1",
+                "StackColor": "#000000",
+                "TriggerDescription": {
+                    "Rotate": "",
+                    "Push": "",
+                    "Touch": ""
+                }
+            }
+        },
+        {
+            "UUID": "io.github.verygoodplugins.streamdeck-mcp.dial.b1",
+            "Name": "MCP Dial ($B1 — progress)",
+            "Tooltip": "streamdeck-mcp dial with Elgato built-in $B1 layout (title + icon + progress bar).",
+            "Icon": "Images/action",
+            "PropertyInspectorPath": "",
+            "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
+            "Controllers": ["Encoder"],
+            "Encoder": {
+                "layout": "$B1",
+                "StackColor": "#000000",
+                "TriggerDescription": {
+                    "Rotate": "",
+                    "Push": "",
+                    "Touch": ""
+                }
+            }
+        },
+        {
+            "UUID": "io.github.verygoodplugins.streamdeck-mcp.dial.b2",
+            "Name": "MCP Dial ($B2 — gradient progress)",
+            "Tooltip": "streamdeck-mcp dial with Elgato built-in $B2 layout (title + icon + gradient progress bar).",
+            "Icon": "Images/action",
+            "PropertyInspectorPath": "",
+            "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
+            "Controllers": ["Encoder"],
+            "Encoder": {
+                "layout": "$B2",
+                "StackColor": "#000000",
+                "TriggerDescription": {
+                    "Rotate": "",
+                    "Push": "",
+                    "Touch": ""
+                }
+            }
+        },
+        {
+            "UUID": "io.github.verygoodplugins.streamdeck-mcp.dial.c1",
+            "Name": "MCP Dial ($C1 — dual rows)",
+            "Tooltip": "streamdeck-mcp dial with Elgato built-in $C1 layout (title + dual icon/progress rows).",
+            "Icon": "Images/action",
+            "PropertyInspectorPath": "",
+            "States": [{ "Image": "Images/action", "TitleAlignment": "bottom" }],
+            "Controllers": ["Encoder"],
+            "Encoder": {
+                "layout": "$C1",
                 "StackColor": "#000000",
                 "TriggerDescription": {
                     "Rotate": "",

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -873,6 +873,38 @@ def test_install_mcp_plugin_idempotent(tmp_path: Path, monkeypatch: pytest.Monke
     assert forced["installed"] is True
 
 
+def test_install_mcp_plugin_upgrades_outdated_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ensure_mcp_plugin_installed reinstalls when the installed manifest version is older."""
+    import json as _json
+
+    from profile_manager import ensure_mcp_plugin_installed
+    from streamdeck_plugin import PLUGIN_DIR_NAME
+
+    plugins_dir = tmp_path / "plugins"
+    monkeypatch.setattr("profile_manager.get_plugins_dir", lambda: plugins_dir)
+
+    # Install the current version first.
+    ensure_mcp_plugin_installed()
+
+    # Simulate an older installed version by overwriting the manifest version.
+    manifest_path = plugins_dir / PLUGIN_DIR_NAME / "manifest.json"
+    manifest = _json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["Version"] = "0.0.1"
+    manifest_path.write_text(_json.dumps(manifest), encoding="utf-8")
+
+    # Should detect the version mismatch and reinstall.
+    result = ensure_mcp_plugin_installed()
+    assert result["installed"] is True
+
+    # Reinstalled manifest should now carry the current bundled version.
+    from streamdeck_plugin import PLUGIN_VERSION
+
+    reinstalled_version = _json.loads(manifest_path.read_text(encoding="utf-8")).get("Version")
+    assert reinstalled_version == PLUGIN_VERSION
+
+
 def test_write_page_encoder_writes_encoder_icon_and_background(
     sample_profiles_plus_xl: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1092,7 +1124,8 @@ def test_write_page_rejects_encoder_layout_on_keypad(
         generated_icons_dir=tmp_path / "icons",
     )
 
-    with pytest.raises(ProfileValidationError, match="encoder_layout"):
+    # With other action fields: should raise encoder-only error, not "do not combine".
+    with pytest.raises(ProfileValidationError, match="encoder_layout is only valid"):
         manager.write_page(
             profile_name="Default Profile",
             directory_id="BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
@@ -1102,6 +1135,31 @@ def test_write_page_rejects_encoder_layout_on_keypad(
                     "title": "Nope",
                     "encoder_layout": "$A1",
                     "action_type": "next_page",
+                }
+            ],
+        )
+
+
+def test_write_page_rejects_encoder_layout_on_keypad_no_other_fields(
+    sample_profiles_v3: Path, tmp_path: Path
+) -> None:
+    """encoder_layout on a keypad button with no other action fields must raise the
+    encoder-only error, not the generic 'Button needs either...' error."""
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_v3,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+
+    with pytest.raises(ProfileValidationError, match="encoder_layout is only valid"):
+        manager.write_page(
+            profile_name="Default Profile",
+            directory_id="BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+            buttons=[
+                {
+                    "key": 0,
+                    "title": "Nope",
+                    "encoder_layout": "$A1",
                 }
             ],
         )

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -974,3 +974,167 @@ def test_write_page_auto_installs_mcp_plugin_for_encoder_default(
     )
     assert result["mcp_plugin_install"]["installed"] is True
     assert (plugins_dir / PLUGIN_DIR_NAME / "manifest.json").exists()
+
+
+def _read_plus_xl_encoder_action(profiles_dir: Path, key: str) -> dict:
+    raw = json.loads(
+        (
+            profiles_dir
+            / "PLUSXL.sdProfile"
+            / "Profiles"
+            / "DDDDDDDD-DDDD-DDDD-DDDD-DDDDDDDDDDDD"
+            / "manifest.json"
+        ).read_text()
+    )
+    encoder_actions = next(
+        c["Actions"] for c in raw["Controllers"] if c["Type"] == "Encoder"
+    )
+    return encoder_actions[key]
+
+
+def test_write_page_encoder_layout_routes_to_variant_uuid(
+    sample_profiles_plus_xl: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from streamdeck_plugin import LAYOUT_ACTION_UUIDS, PLUGIN_UUID
+
+    monkeypatch.setattr("profile_manager.get_plugins_dir", lambda: tmp_path / "plugins")
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_plus_xl,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    icon = manager.create_icon(icon="mdi:volume-high", filename="vol")
+
+    manager.write_page(
+        profile_name="Plus XL",
+        page_index=0,
+        buttons=[
+            {
+                "controller": "encoder",
+                "key": 0,
+                "icon_path": icon["path"],
+                "title": "Volume",
+                "encoder_layout": "$A1",
+            }
+        ],
+        clear_existing=False,
+    )
+
+    action = _read_plus_xl_encoder_action(sample_profiles_plus_xl, "0,0")
+    assert action["UUID"] == LAYOUT_ACTION_UUIDS["$A1"]
+    assert action["Plugin"]["UUID"] == PLUGIN_UUID
+    assert action["Encoder"]["Icon"].startswith("Images/")
+
+
+def test_write_page_encoder_layout_default_uses_default_uuid(
+    sample_profiles_plus_xl: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from streamdeck_plugin import DEFAULT_ACTION_UUID
+
+    monkeypatch.setattr("profile_manager.get_plugins_dir", lambda: tmp_path / "plugins")
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_plus_xl,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    icon = manager.create_icon(icon="mdi:volume-high", filename="vol")
+
+    manager.write_page(
+        profile_name="Plus XL",
+        page_index=0,
+        buttons=[
+            {
+                "controller": "encoder",
+                "key": 0,
+                "icon_path": icon["path"],
+                "title": "Volume",
+            }
+        ],
+        clear_existing=False,
+    )
+
+    action = _read_plus_xl_encoder_action(sample_profiles_plus_xl, "0,0")
+    assert action["UUID"] == DEFAULT_ACTION_UUID
+
+
+def test_write_page_rejects_unknown_encoder_layout(
+    sample_profiles_plus_xl: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("profile_manager.get_plugins_dir", lambda: tmp_path / "plugins")
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_plus_xl,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+
+    with pytest.raises(ProfileValidationError, match=r"\$A1"):
+        manager.write_page(
+            profile_name="Plus XL",
+            page_index=0,
+            buttons=[
+                {
+                    "controller": "encoder",
+                    "key": 0,
+                    "title": "Nope",
+                    "encoder_layout": "$Z9",
+                }
+            ],
+            clear_existing=False,
+        )
+
+
+def test_write_page_rejects_encoder_layout_on_keypad(
+    sample_profiles_v3: Path, tmp_path: Path
+) -> None:
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_v3,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+
+    with pytest.raises(ProfileValidationError, match="encoder_layout"):
+        manager.write_page(
+            profile_name="Default Profile",
+            directory_id="BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB",
+            buttons=[
+                {
+                    "key": 0,
+                    "title": "Nope",
+                    "encoder_layout": "$A1",
+                    "action_type": "next_page",
+                }
+            ],
+        )
+
+
+def test_write_page_auto_installs_mcp_plugin_for_layout_variant(
+    sample_profiles_plus_xl: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from streamdeck_plugin import PLUGIN_DIR_NAME
+
+    plugins_dir = tmp_path / "plugins"
+    monkeypatch.setattr("profile_manager.get_plugins_dir", lambda: plugins_dir)
+
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_plus_xl,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    icon = manager.create_icon(icon="mdi:volume-high", filename="vol")
+
+    result = manager.write_page(
+        profile_name="Plus XL",
+        page_index=0,
+        buttons=[
+            {
+                "controller": "encoder",
+                "key": 0,
+                "icon_path": icon["path"],
+                "title": "V",
+                "encoder_layout": "$B1",
+            }
+        ],
+        clear_existing=False,
+    )
+    assert result["mcp_plugin_install"]["installed"] is True
+    assert (plugins_dir / PLUGIN_DIR_NAME / "manifest.json").exists()


### PR DESCRIPTION
## Summary

Opts callers into Elgato's six built-in touchstrip layouts (`$X1` / `$A0` / `$A1` / `$B1` / `$B2` / `$C1`) via a new `encoder_layout` field on `streamdeck_write_page`. Unlocks progress bars ($B1/$B2), icon+value readouts ($A1), dual-row ($C1), full-canvas image ($A0), and centered-icon ($X1) composition on the Stream Deck + / + XL touchstrip.

The default action (no layout declared) is unchanged — callers who rely on full-strip `Controllers[Encoder].Background` show-through keep that behavior unless they explicitly pick a layout variant. Picking a variant forgoes show-through by Elgato design (a declared layout replaces the default composition).

## Design

Static multi-UUID action variants. Each of the six layouts gets its own action UUID in the bundled plugin manifest with `Encoder.layout` declared — the Elgato-documented, durable site. No plugin-JS changes (stays the no-op registration shell from #20). No per-instance `Controllers[Encoder].Layout` writes (undocumented; stripping risk à la PR #20's `Resources.Encoder.*` lesson).

| Action UUID suffix | Layout | Effect |
|---|---|---|
| `.dial` (default) | *none* | Elgato default composition, full-strip show-through |
| `.dial.x1` | `$X1` | Title + centered icon |
| `.dial.a0` | `$A0` | Title + full-width image canvas |
| `.dial.a1` | `$A1` | Title + icon + value slot |
| `.dial.b1` | `$B1` | Title + icon + progress bar |
| `.dial.b2` | `$B2` | Title + icon + gradient progress |
| `.dial.c1` | `$C1` | Dual icon/progress rows |

Plugin manifest version bumped `0.1.0 → 0.2.0`.

## API

```jsonc
{
  "controller": "encoder",
  "key": 0,
  "title": "Volume",
  "icon_path": "/path/to/72x72.png",
  "encoder_layout": "$A1"   // ← new, optional, enum
}
```

- `encoder_layout` is encoder-only (keypad buttons reject it).
- Unknown values rejected with the supported-enum in the error message.
- Cannot combine with `path`/`action_type`/`plugin_uuid`/`action_uuid` — it's a convenience field for the built-in MCP dial; advanced callers who specify their own plugin/action should declare layout in their own plugin manifest.

## Out of scope (deliberately deferred)

- **Custom JSON layouts.** Clean support needs either (a) a generic action with JS that reads `Settings.layoutPath` — which reintroduces the JS-logic coupling #20 deliberately avoided — or (b) one action UUID per shipped custom layout, premature without a concrete layout in hand.
- **Runtime `setFeedbackLayout`.** Overlaps with the future `setFeedback` dynamic-value experiment. Build once there's a live-value use case.

## Test plan

- [x] `uv run pytest tests/` — 69 passing (64 + 5 new)
- [x] `uv run ruff check .` — clean
- [x] `uv build --wheel` — all 7 action entries ship inside the plugin bundle, plugin manifest version 0.2.0
- [x] On-device (Stream Deck + XL): write one page with six encoder buttons (one per layout variant), visually confirm each renders with the declared composition, quit + relaunch Elgato app, confirm all layouts persist
- [x] On-device: confirm default (no `encoder_layout`) still shows full-strip background show-through

New tests:
- `test_write_page_encoder_layout_routes_to_variant_uuid` — `$A1` → `.dial.a1` UUID
- `test_write_page_encoder_layout_default_uses_default_uuid` — omit → `.dial` UUID
- `test_write_page_rejects_unknown_encoder_layout` — `$Z9` raises with supported enum
- `test_write_page_rejects_encoder_layout_on_keypad` — parallel to `strip_background_path` keypad-rejection
- `test_write_page_auto_installs_mcp_plugin_for_layout_variant` — variant triggers plugin install

🤖 Generated with [Claude Code](https://claude.com/claude-code)