### PR TITLE
feat(skill): streamdeck-designer Agent Skill + MCP transport hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ htmlcov/
 # Local config (user state is stored here, don't track)
 # ~/.streamdeck-mcp/
 /.claude
+streamdeck_assets/skill/*.zip
+streamdeck_assets/skill/*.skill

--- a/README.md
+++ b/README.md
@@ -58,6 +58,41 @@ Or use the packaged legacy entrypoint:
 uvx --from streamdeck-mcp streamdeck-mcp-usb
 ```
 
+## Designing Decks with the `streamdeck-designer` Skill
+
+streamdeck-mcp ships with an **Agent Skill** that teaches Claude how to design, theme, and author complete Stream Deck layouts using the MCP tools below. With the skill loaded, Claude can one-shot an authored deck from a high-level prompt — "give me a hello-kitty-themed Twitch deck with Hue light controls", "build a dev deck for this repo in Nordic colors" — including palette planning, integration discovery, consistent icon generation, and shell-script wiring.
+
+### Install the skill (Claude Code / Claude.ai)
+
+```bash
+# After installing streamdeck-mcp (e.g. via uvx or pip install -e .)
+streamdeck-mcp-install-skill
+# or, without the console script:
+uv run python -m install_skill
+```
+
+The skill is copied to `~/.claude/skills/streamdeck-designer/`. Restart Claude Code (or start a new session) and it auto-loads when your request matches a themed/custom deck design intent.
+
+To upgrade after a `streamdeck-mcp` version bump, rerun with `--force`:
+
+```bash
+streamdeck-mcp-install-skill --force
+```
+
+### Other MCP clients
+
+Clients that don't load Claude Code skills (Claude Desktop, Cursor, ChatGPT-with-MCP, …) get a condensed mirror via the MCP prompt **`design_streamdeck_deck`**. Invoke it before asking for a deck — most clients expose it as a slash command or prompt picker. Pass the user's intent via the `intent` argument if your client supports it.
+
+### What the skill covers
+
+- Hardware inventory — the skill always calls `streamdeck_read_profiles` first, then consults bundled references to match authoring style to the user's model (Original, MK.2, XL, Plus XL, Neo, Mini).
+- Palette + typography planning — 8 theme archetypes (kawaii, retrowave, brutalist, nordic, terminal, nature, minimal, corporate) with ready palettes + per-strategy icon-color guidance.
+- Dials + touchstrip — decision tree for Plus XL encoder layouts (`$X1` / `$A0` / …) with Phase 1 constraints called out (value/indicator slots render empty until the live channel lands).
+- Integration recipes — per-service patterns for Hue, OBS, Spotify, Home Assistant, Twitch, shell, browser. Authoring-time discovery via companion MCPs; credentials stored in `~/StreamDeckScripts/.env`, never baked into scripts.
+- Starter recipes — streamer/hello-kitty (Plus XL), dev/Nordic (XL), music/retrowave (Original) as adaptation shapes.
+
+The skill lives at `streamdeck_assets/skill/streamdeck-designer/` in the repo; the `SKILL.md` body is ≤500 lines and `references/` are loaded on demand.
+
 ## Default Tools
 
 | Tool | What it does |

--- a/install_skill.py
+++ b/install_skill.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Install the bundled streamdeck-designer skill into ~/.claude/skills/.
+
+The skill teaches Claude how to use the streamdeck-mcp tools to author complete,
+themed Stream Deck layouts. Once installed, Claude Code auto-loads it when the
+user's request matches its description (themed decks, service integrations,
+per-hardware layouts).
+
+Usage:
+    uv run python -m install_skill [--force]
+    streamdeck-mcp-install-skill [--force]
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+SKILL_NAME = "streamdeck-designer"
+BUNDLED_SKILL_DIR = Path(__file__).parent / "streamdeck_assets" / "skill" / SKILL_NAME
+SKILLS_ROOT = Path.home() / ".claude" / "skills"
+
+
+def install(force: bool = False) -> dict[str, str | bool]:
+    """Copy the bundled skill to ~/.claude/skills/streamdeck-designer/.
+
+    Returns a dict describing the action taken.
+    """
+    if not BUNDLED_SKILL_DIR.is_dir():
+        return {
+            "installed": False,
+            "error": f"bundled skill not found at {BUNDLED_SKILL_DIR}",
+        }
+
+    target = SKILLS_ROOT / SKILL_NAME
+    if target.exists() and not force:
+        return {
+            "installed": False,
+            "path": str(target),
+            "message": (
+                f"{SKILL_NAME} already installed at {target}. "
+                "Pass --force (or force=True) to overwrite."
+            ),
+        }
+
+    if target.exists():
+        shutil.rmtree(target)
+
+    SKILLS_ROOT.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(BUNDLED_SKILL_DIR, target)
+
+    return {
+        "installed": True,
+        "path": str(target),
+        "message": (
+            f"Installed {SKILL_NAME} to {target}. "
+            "Restart Claude Code (or start a new session) for the skill to load."
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing installation.",
+    )
+    args = parser.parse_args()
+
+    result = install(force=args.force)
+    if "error" in result:
+        print(f"error: {result['error']}", file=sys.stderr)
+        return 1
+    print(result["message"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/install_skill.py
+++ b/install_skill.py
@@ -45,19 +45,27 @@ def install(force: bool = False) -> dict[str, str | bool]:
             ),
         }
 
+    overwrote = False
     if target.exists():
+        overwrote = True
         shutil.rmtree(target)
 
     SKILLS_ROOT.mkdir(parents=True, exist_ok=True)
     shutil.copytree(BUNDLED_SKILL_DIR, target)
 
+    message = f"Installed {SKILL_NAME} to {target}."
+    if overwrote:
+        message = (
+            f"Overwrote existing {SKILL_NAME} at {target} with the bundled "
+            "version — any local edits to that directory are gone."
+        )
+    message += " Restart Claude Code (or start a new session) for the skill to load."
+
     return {
         "installed": True,
         "path": str(target),
-        "message": (
-            f"Installed {SKILL_NAME} to {target}. "
-            "Restart Claude Code (or start a new session) for the skill to load."
-        ),
+        "overwrote": overwrote,
+        "message": message,
     }
 
 
@@ -66,7 +74,12 @@ def main() -> int:
     parser.add_argument(
         "--force",
         action="store_true",
-        help="Overwrite an existing installation.",
+        help=(
+            "Overwrite an existing installation. DESTRUCTIVE: removes the "
+            "target directory and replaces it with the bundled skill. Any "
+            "local edits you made under ~/.claude/skills/streamdeck-designer/ "
+            "will be lost."
+        ),
     )
     args = parser.parse_args()
 

--- a/profile_manager.py
+++ b/profile_manager.py
@@ -911,25 +911,52 @@ class ProfileManager:
             if not isinstance(spec, dict):
                 results.append({"error": f"specs[{index}] must be a dict."})
                 continue
-            scale = spec.get("icon_scale")
+
+            # Coerce per-spec string values that may arrive stringified from
+            # LLM output or transport coercion.
+            scale_raw = spec.get("icon_scale")
+            if isinstance(scale_raw, str):
+                try:
+                    scale_raw = float(scale_raw)
+                except ValueError:
+                    pass  # let downstream raise a clear TypeError/ValueError
+
+            font_size_raw = spec.get("font_size", 18)
+            if isinstance(font_size_raw, str):
+                try:
+                    font_size_raw = int(font_size_raw)
+                except ValueError:
+                    pass
+
+            tb_raw = spec.get("transparent_bg", False)
+            if isinstance(tb_raw, str):
+                lowered = tb_raw.strip().lower()
+                if lowered in ("true", "1", "yes"):
+                    tb_raw = True
+                elif lowered in ("false", "0", "no"):
+                    tb_raw = False
+                # Unrecognized strings (including "") are left as-is;
+                # bool() below will treat non-empty strings as True.
+            transparent_bg = bool(tb_raw)
+
             kwargs = {
                 "text": spec.get("text"),
                 "icon": spec.get("icon"),
                 "icon_color": spec.get("icon_color"),
-                "icon_scale": 1.0 if scale is None else scale,
+                "icon_scale": 1.0 if scale_raw is None else scale_raw,
                 "bg_color": spec.get("bg_color", DEFAULT_BG_COLOR),
                 "text_color": spec.get("text_color", DEFAULT_TEXT_COLOR),
-                "font_size": spec.get("font_size", 18),
+                "font_size": font_size_raw,
                 "filename": spec.get("filename"),
                 "shape": spec.get("shape", "button"),
-                "transparent_bg": bool(spec.get("transparent_bg", False)),
+                "transparent_bg": transparent_bg,
             }
             try:
                 results.append(self.create_icon(**kwargs))
-            except (ProfileValidationError, ProfileManagerError, ValueError) as exc:
+            except (ProfileValidationError, ProfileManagerError, ValueError, TypeError) as exc:
                 # ValueError covers mdi_icons.IconNotFoundError (a ValueError
-                # subclass). Record the failure so one bad spec doesn't abort
-                # the rest of the batch.
+                # subclass). TypeError covers bad numeric types after coercion.
+                # Record the failure so one bad spec doesn't abort the batch.
                 results.append({"error": str(exc), "spec_index": index})
         return results
 

--- a/profile_manager.py
+++ b/profile_manager.py
@@ -79,8 +79,31 @@ MODEL_LAYOUTS: dict[str, dict[str, tuple[int, int]]] = {
     "20GAI9501": {KEYPAD: (3, 2)},
     # Stream Deck Neo (8 keys + touchscreen)
     "20GBD9901": {KEYPAD: (4, 2)},
-    # Emulator used by the Elgato desktop app
+    # Emulator used by the Elgato desktop app ("UI" in older builds, "AI" in recent)
     "UI Stream Deck": {KEYPAD: (4, 2)},
+    "AI Stream Deck": {KEYPAD: (4, 2)},
+    # NOTE: the original Stream Deck + (8 keys + 4 dials + 800x100 touchstrip,
+    # released 2022) has not yet been observed in a profile manifest and its
+    # Elgato-app product ID is unknown. When a profile reports an unknown Model
+    # with encoders present, _resolve_layout falls back to the 5x3 default — add
+    # that model's ID here (with ENCODER: (4, 1) and KEYPAD: (4, 2)) when seen.
+}
+
+# Human-readable names for the model IDs the Elgato desktop app writes to
+# profile manifests. Surfaced in streamdeck_read_profiles so LLMs don't have to
+# cross-reference product IDs against docs (and mis-translate them under the
+# pressure of a complex authoring session). Source: Elgato app profile
+# manifests observed in the wild; kept in sync with MODEL_LAYOUTS above.
+MODEL_NAMES: dict[str, str] = {
+    "20GBA9901": "Stream Deck Original",
+    "20GAA9901": "Stream Deck MK.2",
+    "20GAT9902": "Stream Deck XL",
+    "20GBA9902": "Stream Deck XL rev2",
+    "20GBX9901": "Stream Deck + XL",
+    "20GAI9501": "Stream Deck Mini",
+    "20GBD9901": "Stream Deck Neo",
+    "UI Stream Deck": "UI Stream Deck (emulator)",
+    "AI Stream Deck": "AI Stream Deck (virtual deck / Elgato app companion)",
 }
 
 # The Elgato Stream Deck desktop app caches every profile in memory and rewrites the
@@ -474,6 +497,12 @@ class ProfileManager:
         for profile_dir in sorted(self.profiles_dir.glob("*.sdProfile")):
             manifest = _load_json(profile_dir / "manifest.json")
             page_refs = self._page_refs(profile_dir, manifest)
+            device = dict(manifest.get("Device") or {})
+            model_id = device.get("Model")
+            if model_id and "ModelName" not in device:
+                device["ModelName"] = MODEL_NAMES.get(
+                    model_id, f"Unknown Stream Deck model ({model_id})"
+                )
             profiles.append(
                 {
                     "profile_id": profile_dir.stem,
@@ -482,7 +511,7 @@ class ProfileManager:
                     "profiles_dir": str(self.profiles_dir),
                     "profiles_root": self.profiles_dir.name,
                     "profile_path": str(profile_dir),
-                    "device": manifest.get("Device", {}),
+                    "device": device,
                     "current_page_uuid": manifest.get("Pages", {}).get("Current"),
                     "default_page_uuid": manifest.get("Pages", {}).get("Default"),
                     "page_count": len(page_refs),
@@ -856,6 +885,53 @@ class ProfileManager:
         if canonical_icon_name:
             result["icon"] = f"mdi:{canonical_icon_name}"
         return result
+
+    def create_icons(
+        self,
+        specs: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """Generate multiple icons in one call.
+
+        Each element of ``specs`` is a dict of keyword arguments passed through to
+        ``create_icon``. Returns a list of result dicts in the same order. If one
+        icon fails its validation, the returned entry carries an ``"error"`` key
+        with the message so a single bad spec doesn't abort the rest of the batch.
+
+        This exists so LLMs authoring full decks (32 keypad icons + 6 dial icons
+        is normal) don't round-trip one MCP call per icon and time out.
+        """
+
+        if not isinstance(specs, list) or not specs:
+            raise ProfileValidationError(
+                "create_icons requires a non-empty list of icon specs."
+            )
+
+        results: list[dict[str, Any]] = []
+        for index, spec in enumerate(specs):
+            if not isinstance(spec, dict):
+                results.append({"error": f"specs[{index}] must be a dict."})
+                continue
+            scale = spec.get("icon_scale")
+            kwargs = {
+                "text": spec.get("text"),
+                "icon": spec.get("icon"),
+                "icon_color": spec.get("icon_color"),
+                "icon_scale": 1.0 if scale is None else scale,
+                "bg_color": spec.get("bg_color", DEFAULT_BG_COLOR),
+                "text_color": spec.get("text_color", DEFAULT_TEXT_COLOR),
+                "font_size": spec.get("font_size", 18),
+                "filename": spec.get("filename"),
+                "shape": spec.get("shape", "button"),
+                "transparent_bg": bool(spec.get("transparent_bg", False)),
+            }
+            try:
+                results.append(self.create_icon(**kwargs))
+            except (ProfileValidationError, ProfileManagerError, ValueError) as exc:
+                # ValueError covers mdi_icons.IconNotFoundError (a ValueError
+                # subclass). Record the failure so one bad spec doesn't abort
+                # the rest of the batch.
+                results.append({"error": str(exc), "spec_index": index})
+        return results
 
     def create_action(
         self,

--- a/profile_server.py
+++ b/profile_server.py
@@ -53,6 +53,71 @@ _SKILL_PATH = (
 )
 
 
+def _scalar_or_string(base_type: str) -> dict[str, Any]:
+    """Schema helper: field accepts either a native JSON value or a string
+    form of it. Works around MCP clients (notably Claude Code's tool-call
+    transport as of April 2026) that serialize non-string tool-call
+    arguments as JSON strings before schema validation runs.
+
+    ``base_type`` is one of 'integer', 'number', 'boolean'. For arrays, use a
+    custom ``oneOf`` that preserves the ``items`` schema for the array branch.
+    """
+
+    return {"oneOf": [{"type": base_type}, {"type": "string"}]}
+
+
+def _coerce_arguments(
+    arguments: dict[str, Any],
+    *,
+    ints: tuple[str, ...] = (),
+    nums: tuple[str, ...] = (),
+    bools: tuple[str, ...] = (),
+    arrays: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    """Convert stringified tool arguments back to native types.
+
+    MCP clients sometimes stringify typed args in transit (Claude Code does
+    this with booleans, numbers, integers and nested arrays). Schemas here
+    declare ``oneOf [native, string]`` so validation passes either shape;
+    this helper normalizes before the handler runs. Unknown/unconvertible
+    strings are left as-is so the downstream handler's error message wins.
+    """
+
+    out = dict(arguments)
+    for key in ints:
+        v = out.get(key)
+        if isinstance(v, str):
+            try:
+                out[key] = int(v)
+            except ValueError:
+                pass
+    for key in nums:
+        v = out.get(key)
+        if isinstance(v, str):
+            try:
+                out[key] = float(v)
+            except ValueError:
+                pass
+    for key in bools:
+        v = out.get(key)
+        if isinstance(v, str):
+            lowered = v.strip().lower()
+            if lowered in ("true", "1", "yes"):
+                out[key] = True
+            elif lowered in ("false", "0", "no", ""):
+                out[key] = False
+    for key in arrays:
+        v = out.get(key)
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    out[key] = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+    return out
+
+
 @server.list_tools()
 async def list_tools() -> list[Tool]:
     """List available profile writer tools."""
@@ -216,8 +281,11 @@ async def list_tools() -> list[Tool]:
                         ),
                     },
                     "page_index": {
-                        "type": "integer",
-                        "description": "Zero-based page index from streamdeck_read_profiles.",
+                        **_scalar_or_string("integer"),
+                        "description": (
+                            "Zero-based page index from streamdeck_read_profiles. "
+                            "Accepts int or a string form."
+                        ),
                     },
                     "directory_id": {
                         "type": "string",
@@ -244,45 +312,53 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "profile_name": {"type": "string"},
                     "profile_id": {"type": "string"},
-                    "page_index": {"type": "integer"},
+                    "page_index": {
+                        **_scalar_or_string("integer"),
+                        "description": "Zero-based page index. Accepts int or string form.",
+                    },
                     "directory_id": {"type": "string"},
                     "page_name": {
                         "type": "string",
                         "description": "Optional page name stored in the page manifest.",
                     },
                     "buttons": {
-                        "type": "array",
-                        "items": button_schema,
                         "description": (
-                            "Buttons to write. Use streamdeck_create_action "
-                            "to build Open or script-backed actions."
+                            "Buttons to write. Use streamdeck_create_action to "
+                            "build Open or script-backed actions. Accepts a JSON "
+                            "array or a JSON-encoded string — some MCP clients "
+                            "stringify nested arrays in transit."
                         ),
+                        "oneOf": [
+                            {"type": "array", "items": button_schema},
+                            {"type": "string"},
+                        ],
                     },
                     "clear_existing": {
-                        "type": "boolean",
+                        **_scalar_or_string("boolean"),
                         "description": (
                             "If true, replace the page contents with the "
-                            "provided buttons. Defaults to true."
+                            "provided buttons. Defaults to true. Accepts bool "
+                            "or string form."
                         ),
                     },
                     "create_new": {
-                        "type": "boolean",
+                        **_scalar_or_string("boolean"),
                         "description": "Create a new page instead of updating an existing one.",
                     },
                     "make_current": {
-                        "type": "boolean",
+                        **_scalar_or_string("boolean"),
                         "description": (
                             "When true, make the page the active current page after writing."
                         ),
                     },
                     "auto_quit_app": {
-                        "type": "boolean",
+                        **_scalar_or_string("boolean"),
                         "description": (
                             "If true and the Elgato Stream Deck desktop app is "
                             "running, quit it (graceful AppleScript first, then "
                             "killall) before writing. Required when the app is "
-                            "running or the write will raise an error. Defaults to "
-                            "false so callers must explicitly consent to quitting it."
+                            "running or the write will raise an error. Defaults "
+                            "to false so callers must explicitly consent to quitting it."
                         ),
                     },
                 },
@@ -322,7 +398,7 @@ async def list_tools() -> list[Tool]:
                         ),
                     },
                     "icon_scale": {
-                        "type": "number",
+                        **_scalar_or_string("number"),
                         "description": (
                             "Fraction of the canvas the glyph bounding box fills "
                             "(0.1-1.0). Defaults to 1.0 — edge-to-edge, matching how "
@@ -342,7 +418,7 @@ async def list_tools() -> list[Tool]:
                         ),
                     },
                     "transparent_bg": {
-                        "type": "boolean",
+                        **_scalar_or_string("boolean"),
                         "description": (
                             "Generate an RGBA PNG with a transparent canvas instead of "
                             "filling with bg_color. Use this for dial Icons that overlay a "
@@ -360,10 +436,9 @@ async def list_tools() -> list[Tool]:
                     },
                     "bg_color": {"type": "string"},
                     "text_color": {"type": "string"},
-                    "font_size": {"type": "integer"},
+                    "font_size": _scalar_or_string("integer"),
                     "filename": {"type": "string"},
                     "icons": {
-                        "type": "array",
                         "description": (
                             "Batch generation: a list of icon spec objects, each "
                             "carrying the same fields as a single-icon call "
@@ -372,26 +447,35 @@ async def list_tools() -> list[Tool]:
                             "this field is present, all other single-icon fields "
                             "at the top level are ignored and the response shape "
                             "becomes {\"icons\": [per-spec result]}. Use this for "
-                            "30+ icon decks to avoid per-call round-trip cost."
+                            "30+ icon decks to avoid per-call round-trip cost. "
+                            "Accepts either a JSON array or a JSON-encoded string "
+                            "containing an array — some MCP clients stringify "
+                            "nested arrays in transit."
                         ),
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "icon": {"type": "string"},
-                                "text": {"type": "string"},
-                                "icon_color": {"type": "string"},
-                                "icon_scale": {"type": "number"},
-                                "bg_color": {"type": "string"},
-                                "text_color": {"type": "string"},
-                                "font_size": {"type": "integer"},
-                                "filename": {"type": "string"},
-                                "shape": {
-                                    "type": "string",
-                                    "enum": ["button", "touchstrip"],
+                        "oneOf": [
+                            {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "icon": {"type": "string"},
+                                        "text": {"type": "string"},
+                                        "icon_color": {"type": "string"},
+                                        "icon_scale": {"type": "number"},
+                                        "bg_color": {"type": "string"},
+                                        "text_color": {"type": "string"},
+                                        "font_size": {"type": "integer"},
+                                        "filename": {"type": "string"},
+                                        "shape": {
+                                            "type": "string",
+                                            "enum": ["button", "touchstrip"],
+                                        },
+                                        "transparent_bg": {"type": "boolean"},
+                                    },
                                 },
-                                "transparent_bg": {"type": "boolean"},
                             },
-                        },
+                            {"type": "string"},
+                        ],
                     },
                 },
             },
@@ -453,7 +537,7 @@ async def list_tools() -> list[Tool]:
                 "type": "object",
                 "properties": {
                     "force": {
-                        "type": "boolean",
+                        **_scalar_or_string("boolean"),
                         "description": (
                             "Reinstall the plugin even if it already exists. Useful after "
                             "upgrading streamdeck-mcp."
@@ -468,6 +552,26 @@ async def list_tools() -> list[Tool]:
 @server.call_tool()
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     """Handle profile writer tool calls."""
+
+    # Normalize stringified args from MCP clients that serialize non-string
+    # tool-call parameters as JSON strings in transit. Schemas declare
+    # oneOf [native, string] so validation passes either shape; this brings
+    # the values back to the types the handlers expect.
+    arguments = _coerce_arguments(
+        arguments,
+        ints=("page_index", "font_size", "state", "key"),
+        nums=("icon_scale",),
+        bools=(
+            "clear_existing",
+            "create_new",
+            "make_current",
+            "auto_quit_app",
+            "transparent_bg",
+            "force",
+            "show_title",
+        ),
+        arrays=("buttons", "icons"),
+    )
 
     try:
         if name == "streamdeck_read_profiles":
@@ -500,6 +604,23 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 
         if name == "streamdeck_create_icon":
             batch = arguments.get("icons")
+            if isinstance(batch, str):
+                # Some MCP clients stringify nested arrays in transit
+                # (observed with Claude Code's tool-call serialization).
+                # Parse on the server so callers can pass either shape.
+                try:
+                    batch = json.loads(batch)
+                except json.JSONDecodeError as exc:
+                    return [
+                        TextContent(
+                            type="text",
+                            text=(
+                                "❌ 'icons' was a string but not valid JSON: "
+                                f"{exc}. Pass either a JSON array or a "
+                                "JSON-encoded string."
+                            ),
+                        )
+                    ]
             if batch is not None:
                 icons_result = manager.create_icons(batch)
                 return [

--- a/profile_server.py
+++ b/profile_server.py
@@ -291,13 +291,17 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="streamdeck_create_icon",
             description=(
-                "Generate a 72x72 PNG icon. Supply 'icon' (a Material Design Icons "
-                "name such as 'mdi:cpu-64-bit', 'mdi:volume-high', 'mdi:github') OR "
-                "'text' for a centered text icon — not both. For labels on icon "
-                "buttons, set the button's 'title' field on streamdeck_write_page "
-                "instead of baking text here (Elgato overlays titles on images). "
-                "~7400 MDI icons are bundled and resolved offline; unknown names "
-                "return close-match suggestions. Returns the PNG filesystem path."
+                "Generate one or many 72x72 PNG icons. For a single icon: pass "
+                "'icon' (a Material Design Icons name like 'mdi:cpu-64-bit') OR "
+                "'text' (mutually exclusive with 'icon' — titles go on "
+                "streamdeck_write_page's 'title' field since Elgato overlays them "
+                "on images). For a full deck (often 30+ icons): pass 'icons' as a "
+                "list of spec dicts to generate them all in one call and avoid the "
+                "round-trip timeouts serial calls hit. ~7400 MDI icons bundled "
+                "offline; unknown names return close-match suggestions. Returns "
+                "either a single {path, size, ...} dict or {\"icons\": [...]} when "
+                "'icons' is used (each list element is a per-icon result or an "
+                "{\"error\"} entry for that spec)."
             ),
             inputSchema={
                 "type": "object",
@@ -358,6 +362,37 @@ async def list_tools() -> list[Tool]:
                     "text_color": {"type": "string"},
                     "font_size": {"type": "integer"},
                     "filename": {"type": "string"},
+                    "icons": {
+                        "type": "array",
+                        "description": (
+                            "Batch generation: a list of icon spec objects, each "
+                            "carrying the same fields as a single-icon call "
+                            "(icon/text/icon_color/bg_color/icon_scale/shape/"
+                            "transparent_bg/text_color/font_size/filename). When "
+                            "this field is present, all other single-icon fields "
+                            "at the top level are ignored and the response shape "
+                            "becomes {\"icons\": [per-spec result]}. Use this for "
+                            "30+ icon decks to avoid per-call round-trip cost."
+                        ),
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "icon": {"type": "string"},
+                                "text": {"type": "string"},
+                                "icon_color": {"type": "string"},
+                                "icon_scale": {"type": "number"},
+                                "bg_color": {"type": "string"},
+                                "text_color": {"type": "string"},
+                                "font_size": {"type": "integer"},
+                                "filename": {"type": "string"},
+                                "shape": {
+                                    "type": "string",
+                                    "enum": ["button", "touchstrip"],
+                                },
+                                "transparent_bg": {"type": "boolean"},
+                            },
+                        },
+                    },
                 },
             },
         ),
@@ -464,6 +499,15 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             return [TextContent(type="text", text=json.dumps(result, indent=2))]
 
         if name == "streamdeck_create_icon":
+            batch = arguments.get("icons")
+            if batch is not None:
+                icons_result = manager.create_icons(batch)
+                return [
+                    TextContent(
+                        type="text",
+                        text=json.dumps({"icons": icons_result}, indent=2),
+                    )
+                ]
             _scale = arguments.get("icon_scale")
             result = manager.create_icon(
                 text=arguments.get("text"),

--- a/profile_server.py
+++ b/profile_server.py
@@ -104,8 +104,11 @@ def _coerce_arguments(
             lowered = v.strip().lower()
             if lowered in ("true", "1", "yes"):
                 out[key] = True
-            elif lowered in ("false", "0", "no", ""):
+            elif lowered in ("false", "0", "no"):
                 out[key] = False
+            # Empty strings intentionally pass through — let the handler's
+            # `arguments.get(key, default)` path apply rather than silently
+            # coerce them to False.
     for key in arrays:
         v = out.get(key)
         if isinstance(v, str):
@@ -588,6 +591,21 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
             return [TextContent(type="text", text=json.dumps(payload, indent=2))]
 
         if name == "streamdeck_write_page":
+            # If coercion couldn't parse a stringified `buttons` array,
+            # surface a clear error here instead of letting the downstream
+            # handler iterate the string one char at a time.
+            raw_buttons = arguments.get("buttons")
+            if isinstance(raw_buttons, str):
+                return [
+                    TextContent(
+                        type="text",
+                        text=(
+                            "❌ 'buttons' was a string but not a valid JSON "
+                            "array. Pass either a JSON array or a JSON-encoded "
+                            "string of an array."
+                        ),
+                    )
+                ]
             result = manager.write_page(
                 profile_name=arguments.get("profile_name"),
                 profile_id=arguments.get("profile_id"),

--- a/profile_server.py
+++ b/profile_server.py
@@ -11,11 +11,19 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.types import TextContent, Tool
+from mcp.types import (
+    GetPromptResult,
+    Prompt,
+    PromptArgument,
+    PromptMessage,
+    TextContent,
+    Tool,
+)
 
 from profile_manager import (
     PageNotFoundError,
@@ -35,6 +43,14 @@ logger = logging.getLogger("streamdeck-profile-mcp")
 
 manager = ProfileManager()
 server = Server("streamdeck-profile-mcp")
+
+_SKILL_PATH = (
+    Path(__file__).parent
+    / "streamdeck_assets"
+    / "skill"
+    / "streamdeck-designer"
+    / "SKILL.md"
+)
 
 
 @server.list_tools()
@@ -494,6 +510,86 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     except Exception as exc:  # pragma: no cover
         logger.exception("Unexpected error in %s", name)
         return [TextContent(type="text", text=f"❌ Unexpected error: {exc}")]
+
+
+@server.list_prompts()
+async def list_prompts() -> list[Prompt]:
+    """List MCP prompts. The design_streamdeck_deck prompt mirrors the bundled
+    streamdeck-designer skill for MCP clients that don't load Claude Code skills
+    (Claude Desktop, Cursor, ChatGPT-with-MCP, etc.).
+    """
+
+    return [
+        Prompt(
+            name="design_streamdeck_deck",
+            description=(
+                "Prime Claude with the streamdeck-designer authoring vocabulary: "
+                "hardware inventory, palette/typography planning, integration discovery, "
+                "icon generation, dial layouts, and guardrails. Invoke before authoring "
+                "a themed or integrated Stream Deck layout — especially on clients that "
+                "don't auto-load the bundled Claude Code skill. Optional 'intent' arg "
+                "appends the user's specific ask."
+            ),
+            arguments=[
+                PromptArgument(
+                    name="intent",
+                    description=(
+                        "Optional one-line description of what the user wants "
+                        "(e.g. 'hello-kitty Twitch deck with Hue light controls')."
+                    ),
+                    required=False,
+                ),
+            ],
+        ),
+    ]
+
+
+def _load_skill_body() -> str:
+    """Return the streamdeck-designer SKILL.md body (frontmatter stripped)."""
+
+    try:
+        raw = _SKILL_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return (
+            "# Stream Deck Designer\n\n"
+            "The bundled streamdeck-designer skill was not found at "
+            f"{_SKILL_PATH}. Reinstall streamdeck-mcp or check package data.\n"
+        )
+
+    if raw.startswith("---"):
+        parts = raw.split("---", 2)
+        if len(parts) >= 3:
+            return parts[2].lstrip()
+    return raw
+
+
+@server.get_prompt()
+async def get_prompt(name: str, arguments: dict[str, str] | None) -> GetPromptResult:
+    """Return the design_streamdeck_deck priming message."""
+
+    if name != "design_streamdeck_deck":
+        raise ValueError(f"Unknown prompt: {name}")
+
+    body = _load_skill_body()
+    intent = (arguments or {}).get("intent")
+
+    message_text = body
+    if intent:
+        message_text = (
+            f"{body}\n\n---\n\n"
+            f"User intent for this authoring session: {intent}\n\n"
+            "Apply the guidance above. Start by calling streamdeck_read_profiles."
+        )
+
+    return GetPromptResult(
+        description="Stream Deck authoring vocabulary + the user's intent.",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text=message_text),
+            ),
+        ],
+    )
 
 
 async def main() -> None:

--- a/profile_server.py
+++ b/profile_server.py
@@ -370,16 +370,17 @@ async def list_tools() -> list[Tool]:
         Tool(
             name="streamdeck_create_icon",
             description=(
-                "Generate one or many 72x72 PNG icons. For a single icon: pass "
-                "'icon' (a Material Design Icons name like 'mdi:cpu-64-bit') OR "
-                "'text' (mutually exclusive with 'icon' — titles go on "
-                "streamdeck_write_page's 'title' field since Elgato overlays them "
-                "on images). For a full deck (often 30+ icons): pass 'icons' as a "
-                "list of spec dicts to generate them all in one call and avoid the "
-                "round-trip timeouts serial calls hit. ~7400 MDI icons bundled "
-                "offline; unknown names return close-match suggestions. Returns "
-                "either a single {path, size, ...} dict or {\"icons\": [...]} when "
-                "'icons' is used (each list element is a per-icon result or an "
+                "Generate one or many PNG icons. Button icons are 72x72 px; "
+                "touchstrip segment icons are 200x100 px (use shape='touchstrip'). "
+                "For a single icon: pass 'icon' (a Material Design Icons name like "
+                "'mdi:cpu-64-bit') OR 'text' (mutually exclusive with 'icon' — "
+                "titles go on streamdeck_write_page's 'title' field since Elgato "
+                "overlays them on images). For a full deck (often 30+ icons): pass "
+                "'icons' as a list of spec dicts to generate them all in one call "
+                "and avoid the round-trip timeouts serial calls hit. ~7400 MDI icons "
+                "bundled offline; unknown names return close-match suggestions. "
+                "Returns either a single {path, size, ...} dict or {\"icons\": [...]} "
+                "when 'icons' is used (each list element is a per-icon result or an "
                 "{\"error\"} entry for that spec)."
             ),
             inputSchema={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ build-backend = "setuptools.build_meta"
 [project.scripts]
 streamdeck-mcp = "profile_server:run"
 streamdeck-mcp-usb = "server:run"
+streamdeck-mcp-install-skill = "install_skill:main"
 
 [project.urls]
 Homepage = "https://github.com/verygoodplugins/streamdeck-mcp"
@@ -47,11 +48,19 @@ Issues = "https://github.com/verygoodplugins/streamdeck-mcp/issues"
 name = "io.github.verygoodplugins/streamdeck-mcp"
 
 [tool.setuptools]
-py-modules = ["profile_manager", "profile_server", "server", "mdi_icons"]
+py-modules = ["profile_manager", "profile_server", "server", "mdi_icons", "install_skill"]
 packages = ["streamdeck_assets", "streamdeck_plugin"]
 
 [tool.setuptools.package-data]
-streamdeck_assets = ["*.ttf", "*.json", "MDI-LICENSE"]
+streamdeck_assets = [
+    "*.ttf",
+    "*.json",
+    "MDI-LICENSE",
+    "skill/streamdeck-designer/SKILL.md",
+    "skill/streamdeck-designer/references/*.md",
+    "skill/streamdeck-designer/assets/*.txt",
+    "skill/streamdeck-designer/assets/recipes/*.json",
+]
 streamdeck_plugin = [
     "io.github.verygoodplugins.streamdeck-mcp.sdPlugin/manifest.json",
     "io.github.verygoodplugins.streamdeck-mcp.sdPlugin/plugin.html",

--- a/streamdeck_assets/skill/streamdeck-designer/SKILL.md
+++ b/streamdeck_assets/skill/streamdeck-designer/SKILL.md
@@ -179,6 +179,35 @@ After the write:
 - Use companion MCPs to discover the user's actual scenes/devices — don't guess endpoints.
 - Name actions in `streamdeck_create_action` descriptively (the name becomes the shell script filename — `scene-chill.sh` beats `action1.sh`).
 
+## When you need SDK authority
+
+Elgato's Stream Deck SDK (docs at `https://docs.elgato.com/streamdeck/sdk/`) is the source of truth for anything about deep-link URL grammar, `manifest.json` fields, WebSocket plugin events, touch-strip layouts, or the `streamdeck` CLI. This skill ships a thin primer for the facts used every authoring turn; the rest lives in Context7 or the live docs site. Follow this order.
+
+**1. Primer first for hot paths.** `references/sdk-primer.md` has the deep-link URL grammar, a manifest section cheat sheet (including the `ApplicationsToMonitor` vs "ApplicationMonitoring" pitfall), the full plugin event glossary, and the CLI command table. Read it before round-tripping Context7 for things it already covers.
+
+**2. Context7 for anything the primer doesn't cover.** The Context7 query tool may appear under different namespaces depending on the install — plugin installs expose it as `mcp__plugin_context7_context7__query-docs`; direct MCP installs as `mcp__context7__query-docs`. **Find it by pattern-matching `*context7*query-docs*` against your available-tools list rather than hard-coding a name.**
+
+If the Context7 tools show as deferred (calling them directly errors with `InputValidationError`), load the schemas first with `ToolSearch` using `select:<matched-query-docs-name>,<matched-resolve-library-id-name>`. Without this, your first SDK query will crash.
+
+Then call `query-docs` with:
+- Primary: `libraryId: "/websites/elgato_streamdeck_sdk"` — 874 snippets indexed live from the docs site, benchmark 79.8.
+- Secondary: `libraryId: "/elgatosf/streamdeck"` — the `@elgato/streamdeck` TypeScript SDK package itself, for plugin-authoring code questions.
+
+Pass the user's question verbatim; don't summarize it before the tool sees it.
+
+**3. Fallback — library-ID drift.** If a query against the primary library returns empty or obviously-wrong results, re-run `resolve-library-id` with query `"elgato stream deck sdk"` and use the top-ranked result. The pinned ID above was correct at authoring time but library paths can move.
+
+**4. Fallback — no Context7 at all.** If no `*context7*` tool is available in the session, consult `references/sdk-urls.md`, pick the closest page, and `WebFetch` it.
+
+**5. Red flags — verify, don't emit.** Before writing any SDK-derived fact into code or a user reply, STOP if you catch yourself thinking:
+
+- "I think I know the deep-link URL format" → verify via the primer or Context7.
+- "This event name sounds right (`DialRotate`, `onWillAppear`, …)" → verify.
+- "The manifest probably accepts X" → verify.
+- "`setImage` takes a base64 string, right?" → verify.
+
+All of these mean: do not emit. Look it up first. The primer carries the top sticky facts exactly so you don't round-trip — but fabrication is worse than round-tripping.
+
 ## When the user wants more than static authoring
 
 If they describe behavior like "the dial value updates live as I rotate it," "the button should flash when CI goes red," "I want Claude to render progress as the build runs," or "the button should show what Claude is thinking about" — that's **Phase 2** (live channel, setFeedback wiring, MCP-callback actions). Say so plainly: "That's a live/dynamic behavior; the current MCP handles static authoring. Phase 2 adds the live channel — it's on the roadmap."
@@ -196,3 +225,5 @@ Loaded on demand, not by default. Consult them when:
 - `references/integrations.md` — per-service recipes (Hue, OBS, Spotify, Home Assistant, Twitch, browser, shell).
 - `references/patterns.md` — starter page specs for common deck archetypes (streamer, per-repo dev, music, home-control).
 - `references/troubleshooting.md` — when a write succeeds but the deck doesn't reflect it, icons render wrong, or an encoder icon vanishes after restart.
+- `references/sdk-primer.md` — hot-path SDK facts (deep-link URL grammar, manifest section cheat sheet, WebSocket event glossary, CLI commands). Read first for any SDK-adjacent question.
+- `references/sdk-urls.md` — full index of every `docs.elgato.com/streamdeck/sdk/` and `/cli/` URL. Fallback for `WebFetch` when Context7 is unavailable.

--- a/streamdeck_assets/skill/streamdeck-designer/SKILL.md
+++ b/streamdeck_assets/skill/streamdeck-designer/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: streamdeck-designer
+description: Design, theme, and author complete Stream Deck layouts for the user's hardware using the streamdeck-mcp tools. Use whenever the user wants a custom Stream Deck setup, asks for a themed deck (e.g. "hello-kitty Twitch deck", "retrowave music controls", "a dev deck for this repo"), wants buttons or dials configured for specific apps (OBS, Hue, Spotify, Home Assistant, Twitch, etc.), or asks Claude to "set up" / "build" / "make" / "configure" a Stream Deck page — even if they don't explicitly say "streamdeck-mcp" or "profile." Also triggers when they mention Stream Deck + / + XL dials, encoders, or the touch strip, or when they describe an aesthetic they want reflected on their deck.
+---
+
+# Stream Deck Designer
+
+You are designing a Stream Deck layout for the user. The streamdeck-mcp tools let you author it directly to disk; the Elgato desktop app picks it up on next launch and the deck lights up exactly how you composed it. Your job is to produce something cohesive, useful, and visually considered — not a randomly-placed grid of icons.
+
+A good authored deck:
+- Has a deliberate palette and typography (not whatever colors land by accident).
+- Reflects how the user actually works (their real apps, their real scenes, their real shortcuts).
+- Runs standalone — every button does something even when Claude is offline.
+- Tells the user what each control does without them having to guess.
+
+## Follow this authoring order
+
+Resist the urge to start generating icons before the structure is decided. Every reordering of these steps increases the chance of wasted work.
+
+### 1. Inventory the hardware before anything else
+
+Call `streamdeck_read_profiles` first. This tells you which profiles exist, what model each profile is bound to, and which pages are populated. Never assume a layout — Original (5×3 keys), MK.2 (5×3), XL (8×4), Plus XL (9×4 keys + 6 encoders with a 1200×100 touch strip), Mini (3×2), and Neo (4×2) are all in active use, and the tradeoffs differ. See `references/hardware.md` for per-model guidance.
+
+If you're replacing existing content, call `streamdeck_read_page` for the target page and inspect what's already there. Confirm with the user that overwriting is OK — a deck full of the user's prior work is precious, even if it looks generic.
+
+### 2. Understand intent before designing
+
+Ask, don't guess:
+- What's the activity? (streaming, coding, music, home control, presenting, gaming)
+- What aesthetic? (a theme name like "retrowave" or "hello kitty"; or a color palette; or a reference image)
+- Which integrations? (OBS, Hue, Home Assistant, Spotify, Twitch — specific products, not categories)
+- Which profile and page? (they may have a dedicated profile per activity; don't auto-pick)
+
+Fill gaps with sensible defaults, but if the user gave you a theme name, don't silently reinterpret it. If they said "hello kitty" and you're about to render blue icons, stop and check.
+
+### 3. Plan the palette and typography before rendering any icon
+
+Pick **3–5 colors** before you generate a single icon. Decide the icon-color strategy up front — the three viable ones:
+
+- **Theme-on-neutral**: colored icons on a dark or white bg. High contrast, works on any hardware. The safe default.
+- **Neutral-on-theme**: white or black icons on themed backgrounds. Bolder; good for strong brand aesthetics.
+- **Dual-tone**: alternating pairs. Good for visual rhythm across a large grid but harder to theme consistently.
+
+Pick one strategy and keep it across the whole page. Mixing strategies is what makes a deck look like someone grabbed random emoji.
+
+Show the user the palette (name the colors + one sentence on the strategy) before you start generating icons. Correcting direction after 30 icons exist is expensive.
+
+See `references/themes.md` for archetypes (kawaii, retrowave, brutalist, nordic, terminal, nature, minimal, corporate) with ready palettes and per-archetype icon-color strategies.
+
+### 4. Plan the layout against the hardware
+
+Write out the grid before you author anything. For each slot describe: what lives here, what happens on press, which icon (by MDI name), what title.
+
+On **Plus XL** (the hardware with encoders): encoders are the user's always-visible continuous-control surface — reach for them first for the *most-used continuous values* (volume, brightness, current scene, song scrub). Use keypad slots for discrete actions (toggle, launch, switch). The touch strip is shared across all four rendering slots (200×100 each) — see `references/dials-and-touchstrip.md` for which layout fits which use.
+
+For **XL and Plus XL** (the large grids): group related actions. A row of scene switches stays together. A column of mic controls stays together. The top row gets the most-pressed actions. A cluster of matching colors reads as "these belong together" without words.
+
+For **Original / MK.2 / Neo / Mini**: fewer slots, so every slot matters more. Often the right answer is 2–3 essential actions + navigation to secondary pages, not jamming everything onto one page.
+
+### 5. Discover integrations at authoring time, don't guess endpoints
+
+When the user names an integration, check what you have access to **right now** in this session:
+
+- If a matching MCP is available (Hue MCP, Home Assistant MCP, Spotify MCP, OBS MCP), **use it** to enumerate the user's real devices, scenes, rooms, playlists. The goal is that when the user presses "Chill Scene" on the deck, their actual living-room Hue scene named "Chill" activates — not a placeholder.
+- If no matching MCP is available, **ask the user** for the endpoints, credentials, bridge IPs, auth tokens you need. Tell them plainly what you're going to do with each (e.g. "I'll store your Hue API key in ~/StreamDeckScripts/.env — nothing outside your machine").
+
+Bake the discovered invocations into **shell scripts** via `streamdeck_create_action`. Those scripts run standalone — they don't need Claude or the MCP server to be present at press time. That's the whole point of the static authoring model.
+
+**Never inline credentials into the action scripts.** Put secrets in `~/StreamDeckScripts/.env`; source it in each generated script:
+
+```bash
+#!/bin/bash
+set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+curl -s "http://$HUE_BRIDGE_IP/api/$HUE_API_KEY/groups/1/action" \
+  -X PUT -d '{"scene": "chill-scene-id"}'
+```
+
+See `references/integrations.md` for per-service patterns (Hue, OBS, Spotify, Home Assistant, Twitch, shell/terminal, browser URLs).
+
+### 6. Generate icons with consistent parameters
+
+For every button that needs an icon, call `streamdeck_create_icon` with:
+- Your planned palette's `icon_color` and `bg_color`.
+- For keypad keys that will also show a title at the bottom: `icon_scale` around `0.75`–`0.85` (leaves visual room for the title overlay).
+- For encoder dial faces and any icon that fills its canvas edge-to-edge: `icon_scale=1.0` (matches Elgato's own native icon sizing).
+- For icons that will composite over a touchstrip background: `shape="touchstrip"` for the 200×100 segment background, and `transparent_bg=True` on dial icons that overlay it.
+
+**`icon` and `text` are mutually exclusive.** The Stream Deck app draws the button's `title` *over* its image, so if you bake text into the PNG and also set a title, the text doubles up. For labeled icon buttons: pass only `icon` to `streamdeck_create_icon`, then set `title` in the `streamdeck_write_page` button spec.
+
+If an MDI name misses, `streamdeck_create_icon` returns close-match suggestions. Take them — the exact right glyph for a concept is often named something slightly different (e.g. `mdi:cog` vs `mdi:gear`). `references/icons.md` has 30+ categorized exemplars.
+
+### 7. Wire actions with shell scripts
+
+For commands, use `streamdeck_create_action(name, command)`. It:
+- Writes an executable script to `~/StreamDeckScripts/<slug>.sh`.
+- Returns a native `com.elgato.streamdeck.system.open` action block you pass into `streamdeck_write_page`.
+
+For page navigation between pages in the same profile, use `action_type: "next_page"` or `action_type: "previous_page"` on the button. For opening a URL, `command="open 'https://...'"` works on macOS; Windows uses `start`.
+
+For switching to a **different profile** on press, that's not exposed as a convenience field — build the action object explicitly with `plugin_uuid: "com.elgato.streamdeck.profile"` and the profile-switch action UUID. Most decks don't need this; if you need it, check the Elgato SDK reference.
+
+No other action types exist standalone in Phase 1. In particular: there is no "call back to Claude" action yet — pressing a key fires a shell script or switches a page, nothing else. See Phase 2 in the repo roadmap if the user asks about live/dynamic behavior.
+
+### 8. Pick encoder layouts with the Phase 1 constraint in mind
+
+The bundled plugin ships seven dial variants: a default (`.dial`) that shows the full-strip background through, plus six layout variants (`.dial.x1`/`.a0`/`.a1`/`.b1`/`.b2`/`.c1`) each bound to one of Elgato's built-in touch-strip layouts.
+
+In Phase 1 **only the default `.dial`, `$X1`, and `$A0` render fully.** The value-carrying layouts (`$A1`, `$B1`, `$B2`, `$C1`) have empty `value` / `indicator` slots because that data comes from a live `setFeedback` call in plugin JS, which Phase 1's plugin shell does not make. If the user asks for a "volume bar that ticks up", tell them plainly: that's live-channel behavior and lands in Phase 2 — in the meantime, use `$X1` with a volume icon and a numeric title, or `$A0` with a custom image.
+
+Prefer the default `.dial` (no `encoder_layout` field) for immersive themed decks: author one big 1200×100 touch-strip background image and per-dial icon overlays; the user sees a continuous themed ribbon with their dial icons composed on top. This is the most visually cohesive look on Plus XL.
+
+Set `TriggerDescription` on each encoder so the Stream Deck app's tooltip tells the user what rotate/push/touch do. This is pure manifest — works in Phase 1.
+
+See `references/dials-and-touchstrip.md` for the full decision tree.
+
+### 9. Write in one pass
+
+Batch every button and dial into a single `streamdeck_write_page` call:
+
+```python
+streamdeck_write_page(
+  profile_id="<from step 1>",
+  directory_id="<from step 1>",
+  buttons=[
+    {"controller": "keypad", "key": 0, "title": "Go Live", "icon_path": "...", "action": {...}},
+    {"controller": "keypad", "key": 1, ...},
+    {"controller": "encoder", "key": 0, "title": "Volume", "icon_path": "...", "strip_background_path": "..."},
+    ...
+  ],
+  clear_existing=True,
+  auto_quit_app=True,  # if the Elgato app is running, quit it before writing
+)
+```
+
+The writer refuses to run while the Elgato desktop app is up (its in-memory cache would overwrite your manifest the next time it quits). Pass `auto_quit_app=True` to quit it gracefully. After the write, call `streamdeck_restart_app` so the device reloads with your new layout.
+
+If the page uses encoder buttons, the writer auto-installs the bundled streamdeck-mcp Stream Deck plugin the first time — no separate step needed. You can call `streamdeck_install_mcp_plugin` explicitly if you want to force-reinstall after a plugin version bump.
+
+### 10. Verify before claiming done
+
+After the write:
+1. Call `streamdeck_read_page` and diff against your intended spec. Every button you meant to write should be present; no stray buttons from a previous layout.
+2. Tell the user what to verify on-device — "the deck should show the new layout now; try pressing button 3 to confirm the mic toggle works." Physical verification is on them; don't declare success on their behalf.
+3. If a button depends on credentials in `.env`, check whether that file exists and has placeholders filled in. If not, tell the user which env vars they need to set before the action will work.
+
+## Guardrails
+
+**Don't**:
+- Bake secrets into generated scripts. Always use the `.env` + `source` pattern.
+- Mix `icon` and `text` on the same `streamdeck_create_icon` call — they double up with the title overlay.
+- Use the `$A1/$B1/$B2/$C1` encoder layouts in Phase 1 unless the user has explicitly accepted the empty-value-slot gap.
+- Generate 30 icons with different color hexes because you forgot the planned palette.
+- Overwrite pages without reading them first.
+- Ask the user to quit their Elgato app manually — pass `auto_quit_app=True` and let the tool handle it.
+
+**Do**:
+- Show the palette before rendering icons.
+- Set `TriggerDescription` on every encoder.
+- Prefer a consistent icon-color strategy across the whole page.
+- Use companion MCPs to discover the user's actual scenes/devices — don't guess endpoints.
+- Name actions in `streamdeck_create_action` descriptively (the name becomes the shell script filename — `scene-chill.sh` beats `action1.sh`).
+
+## When the user wants more than static authoring
+
+If they describe behavior like "the dial value updates live as I rotate it," "the button should flash when CI goes red," "I want Claude to render progress as the build runs," or "the button should show what Claude is thinking about" — that's **Phase 2** (live channel, setFeedback wiring, MCP-callback actions). Say so plainly: "That's a live/dynamic behavior; the current MCP handles static authoring. Phase 2 adds the live channel — it's on the roadmap."
+
+Don't try to fake it with heuristics (e.g. a shell script that polls every 5 seconds and rewrites the manifest). Manifest rewrites require the Elgato app to be down, so polling at runtime doesn't work. Better to tell the user the honest shape of the system.
+
+## Reference files
+
+Loaded on demand, not by default. Consult them when:
+
+- `references/hardware.md` — before step 1, if you're unfamiliar with the user's model's tradeoffs.
+- `references/dials-and-touchstrip.md` — whenever the user has a Plus XL or mentions dials/encoders/touchstrip.
+- `references/icons.md` — when picking MDI glyphs; carries 30+ categorized exemplars and scaling guidance.
+- `references/themes.md` — when the user names a theme and you want a starting palette + strategy rather than inventing from scratch.
+- `references/integrations.md` — per-service recipes (Hue, OBS, Spotify, Home Assistant, Twitch, browser, shell).
+- `references/patterns.md` — starter page specs for common deck archetypes (streamer, per-repo dev, music, home-control).
+- `references/troubleshooting.md` — when a write succeeds but the deck doesn't reflect it, icons render wrong, or an encoder icon vanishes after restart.

--- a/streamdeck_assets/skill/streamdeck-designer/SKILL.md
+++ b/streamdeck_assets/skill/streamdeck-designer/SKILL.md
@@ -19,7 +19,9 @@ Resist the urge to start generating icons before the structure is decided. Every
 
 ### 1. Inventory the hardware before anything else
 
-Call `streamdeck_read_profiles` first. This tells you which profiles exist, what model each profile is bound to, and which pages are populated. Never assume a layout — Original (5×3 keys), MK.2 (5×3), XL (8×4), Plus XL (9×4 keys + 6 encoders with a 1200×100 touch strip), Mini (3×2), and Neo (4×2) are all in active use, and the tradeoffs differ. See `references/hardware.md` for per-model guidance.
+Call `streamdeck_read_profiles` first. The response has each profile's `device.Model` (raw Elgato product ID like `20GBX9901`) **and** `device.ModelName` (human-readable, like `"Stream Deck + XL"`). **Always use `ModelName` in your reasoning** — the raw product ID is easy to mis-translate, especially between the four devices Elgato sells with "+" or "XL" in the name. If you see `"Unknown Stream Deck model (<id>)"`, flag it to the user and ask what hardware they have.
+
+Never assume a layout — Original (5×3), MK.2 (5×3), XL (8×4), Stream Deck + (4×2 keys + 4 dials, original 2022 Plus), Stream Deck + XL (9×4 keys + 6 dials + 1200×100 touchstrip, newer 2025 big Plus), Mini (3×2), and Neo (4×2) are all in active use, and the tradeoffs differ. See `references/hardware.md` for per-model guidance and the "+ vs + XL" disambiguation.
 
 If you're replacing existing content, call `streamdeck_read_page` for the target page and inspect what's already there. Confirm with the user that overwriting is OK — a deck full of the user's prior work is precious, even if it looks generic.
 
@@ -77,17 +79,34 @@ curl -s "http://$HUE_BRIDGE_IP/api/$HUE_API_KEY/groups/1/action" \
 
 See `references/integrations.md` for per-service patterns (Hue, OBS, Spotify, Home Assistant, Twitch, shell/terminal, browser URLs).
 
-### 6. Generate icons with consistent parameters
+### 6. Generate icons — batched when the deck is big
 
-For every button that needs an icon, call `streamdeck_create_icon` with:
-- Your planned palette's `icon_color` and `bg_color`.
+**Always batch icon generation for a whole deck into a single `streamdeck_create_icon` call.** The tool accepts an optional `icons` array parameter. A 32-key XL deck authored with 32 serial calls hits round-trip timeouts; the same 32 icons in one batched call complete in a fraction of the time.
+
+Batch call:
+
+```python
+streamdeck_create_icon(icons=[
+    {"icon": "mdi:play-circle",   "icon_color": "#88c0d0", "bg_color": "#2e3440", "filename": "run"},
+    {"icon": "mdi:package-variant","icon_color": "#88c0d0", "bg_color": "#2e3440", "filename": "build"},
+    # ... one spec per button ...
+])
+# returns: {"icons": [{path, size, ...}, {path, size, ...}, ...]}
+```
+
+If one spec fails (e.g. `mdi:cat-face` has no exact match), its slot in the result carries `{"error": "...", "spec_index": N}` and the rest of the batch still succeeds — pick up the fuzzy-match suggestion, fix that one spec, re-batch the failures.
+
+Single-icon calls still work the same way they always did — batch is purely additive.
+
+Icon param conventions:
+- Your planned palette's `icon_color` and `bg_color` on every spec.
 - For keypad keys that will also show a title at the bottom: `icon_scale` around `0.75`–`0.85` (leaves visual room for the title overlay).
 - For encoder dial faces and any icon that fills its canvas edge-to-edge: `icon_scale=1.0` (matches Elgato's own native icon sizing).
 - For icons that will composite over a touchstrip background: `shape="touchstrip"` for the 200×100 segment background, and `transparent_bg=True` on dial icons that overlay it.
 
-**`icon` and `text` are mutually exclusive.** The Stream Deck app draws the button's `title` *over* its image, so if you bake text into the PNG and also set a title, the text doubles up. For labeled icon buttons: pass only `icon` to `streamdeck_create_icon`, then set `title` in the `streamdeck_write_page` button spec.
+**`icon` and `text` are mutually exclusive.** The Stream Deck app draws the button's `title` *over* its image, so if you bake text into the PNG and also set a title, the text doubles up. For labeled icon buttons: pass only `icon` in the spec, then set `title` in the `streamdeck_write_page` button spec.
 
-If an MDI name misses, `streamdeck_create_icon` returns close-match suggestions. Take them — the exact right glyph for a concept is often named something slightly different (e.g. `mdi:cog` vs `mdi:gear`). `references/icons.md` has 30+ categorized exemplars.
+If an MDI name misses, the tool returns close-match suggestions. Take them — the exact right glyph for a concept is often named something slightly different (e.g. `mdi:cog` vs `mdi:gear`). `references/icons.md` has 30+ categorized exemplars.
 
 ### 7. Wire actions with shell scripts
 

--- a/streamdeck_assets/skill/streamdeck-designer/assets/env-template.txt
+++ b/streamdeck_assets/skill/streamdeck-designer/assets/env-template.txt
@@ -1,0 +1,36 @@
+# ~/StreamDeckScripts/.env — credential store for Stream Deck actions
+#
+# This file is sourced by every generated shell script. Fill in the values
+# for the services you actually use; leave the rest commented out.
+#
+# Never commit this file. If you're tracking ~/StreamDeckScripts under git,
+# add `.env` to its .gitignore.
+#
+# File permissions: `chmod 600 ~/StreamDeckScripts/.env` so only your user
+# can read it.
+
+# ——— Philips Hue ———————————————————————————————————————————————
+# HUE_BRIDGE_IP=192.168.1.5
+# HUE_API_KEY=replace-with-your-long-token
+
+# ——— OBS (obs-websocket v5) ————————————————————————————————————
+# OBS_HOST=127.0.0.1
+# OBS_PORT=4455
+# OBS_PASSWORD=your-websocket-password
+
+# ——— Home Assistant ————————————————————————————————————————————
+# HA_URL=http://homeassistant.local:8123
+# HA_TOKEN=your-long-lived-access-token
+
+# ——— Spotify (via spotipy) ———————————————————————————————————————
+# SPOTIFY_CLIENT_ID=
+# SPOTIFY_CLIENT_SECRET=
+# SPOTIFY_REDIRECT_URI=http://localhost:8888/callback
+
+# ——— Twitch ———————————————————————————————————————————————————
+# TWITCH_OAUTH=oauth:your-token
+# TWITCH_CHANNEL=yourchannel
+
+# ——— Custom (add anything the user's integrations need) ————————
+# MY_SERVICE_URL=
+# MY_SERVICE_TOKEN=

--- a/streamdeck_assets/skill/streamdeck-designer/assets/recipes/dev-nordic.json
+++ b/streamdeck_assets/skill/streamdeck-designer/assets/recipes/dev-nordic.json
@@ -1,0 +1,102 @@
+{
+  "_recipe_name": "Developer Deck (Nordic theme)",
+  "_description": "Per-repo XL deck with run/build/test/lint, GitHub shortcuts, Docker controls, editor launchers. Column-grouped by concern; bottom row is meta navigation.",
+  "_hardware_target": "Stream Deck XL (8×4)",
+  "_theme": {
+    "palette": {
+      "polar_night": "#2e3440",
+      "frost": "#88c0d0",
+      "aurora_green": "#a3be8c",
+      "snow_white": "#d8dee9",
+      "aurora_red": "#bf616a"
+    },
+    "strategy": "A: frost/green icons on polar-night; red for destructive/alert",
+    "icon_scale": { "keypad": 0.8 }
+  },
+  "_integrations": ["shell", "browser", "github-cli", "docker"],
+  "_env_required": [],
+  "_adapt_hint": "Before authoring, inspect the user's package.json / Makefile / pyproject.toml and pick the user's actual scripts — don't ship generic 'npm run dev' for a Python repo.",
+
+  "columns": [
+    {
+      "column": 0,
+      "purpose": "Build / run / test / lint",
+      "buttons": [
+        { "key": 0, "title": "Run", "icon": "mdi:play-circle", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "cd {{REPO}} && npm run dev" },
+        { "key": 8, "title": "Build", "icon": "mdi:package-variant", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "cd {{REPO}} && npm run build" },
+        { "key": 16, "title": "Test", "icon": "mdi:test-tube", "icon_color": "#a3be8c", "bg": "#2e3440", "action": "cd {{REPO}} && npm test" },
+        { "key": 24, "title": "Lint", "icon": "mdi:check-circle", "icon_color": "#a3be8c", "bg": "#2e3440", "action": "cd {{REPO}} && npm run lint" }
+      ]
+    },
+    {
+      "column": 1,
+      "purpose": "GitHub / PRs / CI / issues",
+      "buttons": [
+        { "key": 1, "title": "PRs", "icon": "mdi:github", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "open \"https://github.com/{{OWNER}}/{{REPO}}/pulls\"" },
+        { "key": 9, "title": "Branch", "icon": "mdi:source-branch", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "cd {{REPO}} && git branch --show-current | xargs -I{} open \"https://github.com/{{OWNER}}/{{REPO}}/tree/{}\"" },
+        { "key": 17, "title": "CI", "icon": "mdi:robot", "icon_color": "#a3be8c", "bg": "#2e3440", "action": "open \"https://github.com/{{OWNER}}/{{REPO}}/actions\"" },
+        { "key": 25, "title": "Issues", "icon": "mdi:bug", "icon_color": "#bf616a", "bg": "#2e3440", "action": "open \"https://github.com/{{OWNER}}/{{REPO}}/issues\"" }
+      ]
+    },
+    {
+      "column": 2,
+      "purpose": "Docker / environment",
+      "buttons": [
+        { "key": 2, "title": "Up", "icon": "mdi:docker", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "cd {{REPO}} && docker compose up -d" },
+        { "key": 10, "title": "Down", "icon": "mdi:docker", "icon_color": "#bf616a", "bg": "#2e3440", "action": "cd {{REPO}} && docker compose down" },
+        { "key": 18, "title": "Logs", "icon": "mdi:file-document", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "open -a \"Terminal\" && osascript -e 'tell application \"Terminal\" to do script \"cd {{REPO}} && docker compose logs -f\"'" },
+        { "key": 26, "title": "Restart", "icon": "mdi:restart", "icon_color": "#a3be8c", "bg": "#2e3440", "action": "cd {{REPO}} && docker compose restart" }
+      ]
+    },
+    {
+      "column": 3,
+      "purpose": "Repo-specific scripts (populate from package.json / Makefile)",
+      "buttons": [
+        { "key": 3, "title": "{{SCRIPT_A}}", "icon": "mdi:console", "action": "cd {{REPO}} && {{CMD_A}}" },
+        { "key": 11, "title": "{{SCRIPT_B}}", "icon": "mdi:console", "action": "cd {{REPO}} && {{CMD_B}}" },
+        { "key": 19, "title": "{{SCRIPT_C}}", "icon": "mdi:console", "action": "cd {{REPO}} && {{CMD_C}}" },
+        { "key": 27, "title": "{{SCRIPT_D}}", "icon": "mdi:console", "action": "cd {{REPO}} && {{CMD_D}}" }
+      ]
+    },
+    {
+      "column": 4,
+      "purpose": "Git operations (deliberate — pressing 'Push' should be meaningful)",
+      "buttons": [
+        { "key": 4, "title": "Status", "icon": "mdi:format-list-bulleted", "action": "open -a Terminal && osascript -e 'tell application \"Terminal\" to do script \"cd {{REPO}} && git status\"'" },
+        { "key": 12, "title": "Pull", "icon": "mdi:cloud-download", "icon_color": "#88c0d0", "bg": "#2e3440", "action": "cd {{REPO}} && git pull" },
+        { "key": 20, "title": "Push", "icon": "mdi:cloud-upload", "icon_color": "#a3be8c", "bg": "#2e3440", "action": "cd {{REPO}} && git push" },
+        { "key": 28, "title": "Log", "icon": "mdi:history", "action": "open -a Terminal && osascript ..." }
+      ]
+    },
+    {
+      "column": 5,
+      "purpose": "Project-specific dashboards",
+      "buttons": [
+        { "key": 5, "title": "Vercel", "icon": "mdi:triangle", "action": "open \"https://vercel.com/{{TEAM}}/{{PROJECT}}\"" },
+        { "key": 13, "title": "Sentry", "icon": "mdi:alert-circle", "action": "open \"https://sentry.io/organizations/{{ORG}}/issues/\"" },
+        { "key": 21, "title": "Linear", "icon": "mdi:calendar-check", "action": "open \"https://linear.app/{{TEAM}}\"" },
+        { "key": 29, "title": "Docs", "icon": "mdi:book-open-variant", "action": "open \"https://{{DOCS_URL}}\"" }
+      ]
+    },
+    {
+      "column": 6,
+      "purpose": "Utilities",
+      "buttons": [
+        { "key": 6, "title": "Clean", "icon": "mdi:broom", "icon_color": "#bf616a", "action": "cd {{REPO}} && rm -rf node_modules dist" },
+        { "key": 14, "title": "Reinstall", "icon": "mdi:download", "action": "cd {{REPO}} && npm ci" },
+        { "key": 22, "title": "Format", "icon": "mdi:format-indent-increase", "action": "cd {{REPO}} && npm run format" },
+        { "key": 30, "title": "Open .env", "icon": "mdi:key-variant", "action": "code {{REPO}}/.env" }
+      ]
+    },
+    {
+      "column": 7,
+      "purpose": "Editor / terminal / navigation",
+      "buttons": [
+        { "key": 7, "title": "Code", "icon": "mdi:microsoft-visual-studio-code", "action": "code {{REPO}}" },
+        { "key": 15, "title": "Term", "icon": "mdi:console", "action": "open -a \"Terminal\" {{REPO}}" },
+        { "key": 23, "title": "Config", "icon": "mdi:cog", "action": "code {{REPO}}/package.json" },
+        { "key": 31, "title": "Switch", "action_type": "next_page", "icon": "mdi:arrow-right" }
+      ]
+    }
+  ]
+}

--- a/streamdeck_assets/skill/streamdeck-designer/assets/recipes/music-retrowave.json
+++ b/streamdeck_assets/skill/streamdeck-designer/assets/recipes/music-retrowave.json
@@ -1,0 +1,55 @@
+{
+  "_recipe_name": "Music Player (Retrowave)",
+  "_description": "15-key playback deck for the Original / MK.2. Three rows: playback, volume+playlist shortcuts, discovery/utilities. Uses Spotify via spotipy wrappers; substitute Apple Music via osascript if the user prefers.",
+  "_hardware_target": "Stream Deck Original / MK.2 (5×3)",
+  "_theme": {
+    "palette": {
+      "neon_pink": "#ff006e",
+      "cyan": "#00f5ff",
+      "purple": "#7209b7",
+      "midnight": "#1a1a2e",
+      "sun_yellow": "#ffb703"
+    },
+    "strategy": "B: neon/cyan glyphs on midnight backgrounds. No whites.",
+    "icon_scale": { "keypad": 0.85 }
+  },
+  "_integrations": ["spotipy", "osascript"],
+  "_env_required": ["SPOTIFY_CLIENT_ID", "SPOTIFY_CLIENT_SECRET", "SPOTIFY_REDIRECT_URI"],
+  "_adapt_hint": "User's actual playlist URIs replace placeholders. Spotify OAuth refresh token must be cached via spotipy before buttons fire — run the one-time auth flow first.",
+
+  "rows": [
+    {
+      "row": 0,
+      "purpose": "Playback transport",
+      "buttons": [
+        { "key": 0, "title": "Back", "icon": "mdi:skip-previous", "icon_color": "#00f5ff", "bg": "#1a1a2e", "action": "python3 -c \"import spotipy; from spotipy.oauth2 import SpotifyOAuth; spotipy.Spotify(auth_manager=SpotifyOAuth(scope='user-modify-playback-state')).previous_track()\"" },
+        { "key": 1, "title": "Play", "icon": "mdi:play", "icon_color": "#ff006e", "bg": "#1a1a2e", "action": "python3 -c \"... sp.start_playback()\"" },
+        { "key": 2, "title": "Pause", "icon": "mdi:pause", "icon_color": "#ff006e", "bg": "#1a1a2e", "action": "python3 -c \"... sp.pause_playback()\"" },
+        { "key": 3, "title": "Next", "icon": "mdi:skip-next", "icon_color": "#00f5ff", "bg": "#1a1a2e", "action": "python3 -c \"... sp.next_track()\"" },
+        { "key": 4, "title": "Shuffle", "icon": "mdi:shuffle-variant", "icon_color": "#ffb703", "bg": "#1a1a2e", "action": "python3 -c \"... sp.shuffle(True)\"" }
+      ]
+    },
+    {
+      "row": 1,
+      "purpose": "Volume + playlist moods",
+      "buttons": [
+        { "key": 5, "title": "Vol -", "icon": "mdi:volume-low", "icon_color": "#00f5ff", "bg": "#1a1a2e", "action": "python3 -c \"... sp.volume(max(0, sp.current_playback()['device']['volume_percent'] - 10))\"" },
+        { "key": 6, "title": "Vol +", "icon": "mdi:volume-high", "icon_color": "#00f5ff", "bg": "#1a1a2e", "action": "python3 -c \"... sp.volume(min(100, sp.current_playback()['device']['volume_percent'] + 10))\"" },
+        { "key": 7, "title": "Chill", "icon": "mdi:music-note-eighth", "icon_color": "#ff006e", "bg": "#1a1a2e", "action": "python3 -c \"... sp.start_playback(context_uri='{{PLAYLIST_URI_CHILL}}')\"" },
+        { "key": 8, "title": "Focus", "icon": "mdi:headphones", "icon_color": "#ff006e", "bg": "#1a1a2e", "action": "python3 -c \"... sp.start_playback(context_uri='{{PLAYLIST_URI_FOCUS}}')\"" },
+        { "key": 9, "title": "Retro", "icon": "mdi:cassette", "icon_color": "#ffb703", "bg": "#1a1a2e", "action": "python3 -c \"... sp.start_playback(context_uri='{{PLAYLIST_URI_RETROWAVE}}')\"" }
+      ]
+    },
+    {
+      "row": 2,
+      "purpose": "Discovery + utilities",
+      "buttons": [
+        { "key": 10, "title": "Spotify", "icon": "mdi:spotify", "icon_color": "#00f5ff", "bg": "#1a1a2e", "action": "open -a \"Spotify\"" },
+        { "key": 11, "title": "Save", "icon": "mdi:heart", "icon_color": "#ff006e", "bg": "#1a1a2e", "action": "python3 -c \"... uri = sp.current_playback()['item']['uri']; sp.current_user_saved_tracks_add([uri])\"" },
+        { "key": 12, "title": "Queue", "icon": "mdi:playlist-plus", "icon_color": "#00f5ff", "bg": "#1a1a2e", "action": "python3 -c \"... prompt user (hard in static; consider manual flow)\"" },
+        { "key": 13, "title": "Mute", "icon": "mdi:volume-off", "icon_color": "#bf616a", "bg": "#1a1a2e", "action": "osascript -e 'set volume output muted true'" },
+        { "key": 14, "title": "Unmute", "icon": "mdi:volume-high", "icon_color": "#a3be8c", "bg": "#1a1a2e", "action": "osascript -e 'set volume output muted false'" }
+      ]
+    }
+  ]
+}

--- a/streamdeck_assets/skill/streamdeck-designer/assets/recipes/streamer-hello-kitty.json
+++ b/streamdeck_assets/skill/streamdeck-designer/assets/recipes/streamer-hello-kitty.json
@@ -1,0 +1,148 @@
+{
+  "_recipe_name": "Streamer (Hello Kitty theme)",
+  "_description": "Full-strip kawaii streaming deck for Stream Deck + XL. Uses OBS for scene/mic/camera, Hue for room lighting, browser links for dashboards. Encoders reserved for the most-used continuous controls; keypad rows grouped by concern.",
+  "_hardware_target": "Stream Deck + XL (20GBX9901)",
+  "_theme": {
+    "palette": {
+      "primary": "#ff8faa",
+      "pale": "#ffe0f0",
+      "white": "#ffffff",
+      "near_black": "#1a1a1a",
+      "accent_gold": "#ffd700"
+    },
+    "strategy": "A (theme-on-neutral): pink/gold icons on pale-pink or near-black backgrounds",
+    "icon_scale": {
+      "keypad": 0.8,
+      "encoder_icon": 1.0,
+      "touchstrip_bg": 0.7
+    }
+  },
+  "_integrations": ["obs-cli", "hue-rest-api", "twitch-cli", "browser"],
+  "_env_required": ["HUE_BRIDGE_IP", "HUE_API_KEY", "TWITCH_CHANNEL"],
+
+  "encoders": [
+    {
+      "key": 0,
+      "purpose": "Master system volume",
+      "title": "Volume",
+      "icon": "mdi:volume-high",
+      "icon_color": "#ff8faa",
+      "transparent_bg": true,
+      "trigger_description": { "Rotate": "System volume", "Push": "Mute toggle" },
+      "encoder_layout": null,
+      "action_note": "Phase 1: press-only, no live rotation. Bake discrete presets as keypad buttons if needed."
+    },
+    {
+      "key": 1,
+      "purpose": "Mic volume (OBS)",
+      "title": "Mic",
+      "icon": "mdi:microphone",
+      "icon_color": "#ff8faa",
+      "transparent_bg": true,
+      "trigger_description": { "Rotate": "Mic gain", "Push": "Mute toggle" },
+      "action_note": "obs-cli audio toggle \"Mic/Aux\""
+    },
+    {
+      "key": 2,
+      "purpose": "Room brightness (Hue scene)",
+      "title": "Lights",
+      "icon": "mdi:lightbulb-on",
+      "icon_color": "#ffd700",
+      "transparent_bg": true,
+      "trigger_description": { "Rotate": "Brightness", "Push": "Toggle off/on" }
+    },
+    {
+      "key": 3,
+      "purpose": "Chat scroll",
+      "title": "Chat",
+      "icon": "mdi:chat",
+      "icon_color": "#ff8faa",
+      "transparent_bg": true
+    },
+    {
+      "key": 4,
+      "purpose": "Alert volume (OBS audio source)",
+      "title": "Alerts",
+      "icon": "mdi:heart",
+      "icon_color": "#ff8faa",
+      "transparent_bg": true
+    },
+    {
+      "key": 5,
+      "purpose": "Master display brightness (macOS system)",
+      "title": "Bright",
+      "icon": "mdi:brightness-6",
+      "icon_color": "#ffd700",
+      "transparent_bg": true
+    }
+  ],
+
+  "touchstrip_background": {
+    "purpose": "Unified pink gradient across all six segments. Use default .dial UUID for show-through.",
+    "generation": "Generate a 1200x100 PNG externally or use streamdeck_create_icon(shape='touchstrip', bg_color='#ff8faa') as a starting point. For full-strip show-through, set it on the first encoder's strip_background_path.",
+    "color_stops": ["#ff8faa", "#ffe0f0", "#ff8faa"]
+  },
+
+  "keypad_rows": [
+    {
+      "row": 0,
+      "purpose": "Scene switches + go-live",
+      "buttons": [
+        { "key": 0, "title": "Start", "icon": "mdi:play-circle", "action": "obs-cli scene current \"Starting Soon\"", "bg": "#ffe0f0" },
+        { "key": 1, "title": "Chat", "icon": "mdi:chat", "action": "obs-cli scene current \"Just Chatting\"", "bg": "#ffe0f0" },
+        { "key": 2, "title": "Game", "icon": "mdi:gamepad-variant", "action": "obs-cli scene current \"Gameplay\"", "bg": "#ffe0f0" },
+        { "key": 3, "title": "BRB", "icon": "mdi:coffee", "action": "obs-cli scene current \"BRB\"", "bg": "#ffe0f0" },
+        { "key": 4, "title": "End", "icon": "mdi:flag-checkered", "action": "obs-cli scene current \"Ending\"", "bg": "#ffe0f0" },
+        { "key": 5, "title": "Go Live", "icon": "mdi:broadcast", "icon_color": "#ffffff", "bg": "#ff8faa", "action": "obs-cli stream start && obs-cli record start" },
+        { "key": 6, "title": "Welcome", "icon": "mdi:heart", "action": "twitch chat send-message --from-user yourbot --to-channel \"$TWITCH_CHANNEL\" --message \"Welcome to the stream!\"" },
+        { "key": 7, "title": "Lurk", "icon": "mdi:eye-off", "action": "twitch chat send-message ..." },
+        { "key": 8, "title": "Schedule", "icon": "mdi:calendar", "action": "twitch chat send-message --message \"Check my schedule: ...\"" }
+      ]
+    },
+    {
+      "row": 1,
+      "purpose": "Mic / camera / sources / Hue scenes",
+      "buttons": [
+        { "key": 9, "title": "Mic", "icon": "mdi:microphone", "action": "obs-cli audio toggle \"Mic/Aux\"" },
+        { "key": 10, "title": "Cam", "icon": "mdi:camera", "action": "obs-cli audio toggle \"Camera\"" },
+        { "key": 11, "title": "Game", "icon": "mdi:monitor-screenshot", "action": "obs-cli source toggle \"Game Capture\"" },
+        { "key": 12, "title": "Browser", "icon": "mdi:web", "action": "obs-cli source toggle \"Browser Source\"" },
+        { "key": 13, "title": "Alerts", "icon": "mdi:bell", "action": "obs-cli source toggle \"Alerts\"" },
+        { "key": 14, "title": "Chill", "icon": "mdi:palette", "action": "curl -s \"http://$HUE_BRIDGE_IP/api/$HUE_API_KEY/groups/1/action\" -X PUT -d '{\"scene\": \"CHILL_SCENE_ID\"}'" },
+        { "key": 15, "title": "Focus", "icon": "mdi:palette", "action": "curl ... FOCUS_SCENE_ID" },
+        { "key": 16, "title": "Stream", "icon": "mdi:palette", "action": "curl ... STREAM_SCENE_ID" },
+        { "key": 17, "title": "Break", "icon": "mdi:palette", "action": "curl ... BREAK_SCENE_ID" }
+      ]
+    },
+    {
+      "row": 2,
+      "purpose": "Sound effects + overlay toggles",
+      "buttons": [
+        { "key": 18, "title": "Applause", "icon": "mdi:hand-clap", "action": "afplay /path/to/sfx/applause.wav" },
+        { "key": 19, "title": "Laugh", "icon": "mdi:emoticon-happy", "action": "afplay /path/to/sfx/laugh.wav" },
+        { "key": 20, "title": "Win", "icon": "mdi:trophy", "action": "afplay /path/to/sfx/win.wav" },
+        { "key": 21, "title": "Fail", "icon": "mdi:emoticon-sad", "action": "afplay /path/to/sfx/fail.wav" },
+        { "key": 22, "title": "Drum", "icon": "mdi:drum", "action": "afplay /path/to/sfx/drumroll.wav" },
+        { "key": 23, "title": "Ding", "icon": "mdi:bell-ring", "action": "afplay /path/to/sfx/ding.wav" },
+        { "key": 24, "title": "Overlay", "icon": "mdi:layers", "action": "obs-cli source toggle \"Stream Overlay\"" },
+        { "key": 25, "title": "Starting", "icon": "mdi:clock-start", "action": "obs-cli scene current \"Starting Soon\"" },
+        { "key": 26, "title": "Panic", "icon": "mdi:alert", "icon_color": "#ffffff", "bg": "#1a1a1a", "action": "obs-cli scene current \"BRB\" && obs-cli audio toggle \"Mic/Aux\"" }
+      ]
+    },
+    {
+      "row": 3,
+      "purpose": "Utilities / dashboards / nav",
+      "buttons": [
+        { "key": 27, "title": "Twitch", "icon": "mdi:twitch", "action": "open \"https://dashboard.twitch.tv/u/$TWITCH_CHANNEL/stream-manager\"" },
+        { "key": 28, "title": "OBS", "icon": "mdi:video-switch", "action": "open -a \"OBS\"" },
+        { "key": 29, "title": "Discord", "icon": "mdi:discord", "action": "open -a \"Discord\"" },
+        { "key": 30, "title": "All Mute", "icon": "mdi:volume-off", "action": "obs-cli audio toggle \"Mic/Aux\" && obs-cli audio toggle \"Desktop Audio\"" },
+        { "key": 31, "title": "Reset", "icon": "mdi:restart", "action": "obs-cli scene current \"Starting Soon\" && obs-cli source show \"Stream Overlay\"" },
+        { "key": 32, "title": "Prev", "action_type": "previous_page" },
+        { "key": 33, "title": "Next", "action_type": "next_page" },
+        { "key": 34, "title": "Coding", "action": "open -a \"Stream Deck\" && ..." },
+        { "key": 35, "title": "Dev", "action": "profile-switch (build manually)" }
+      ]
+    }
+  ]
+}

--- a/streamdeck_assets/skill/streamdeck-designer/references/dials-and-touchstrip.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/dials-and-touchstrip.md
@@ -1,0 +1,75 @@
+# Dials and the Touch Strip
+
+The Stream Deck + XL's touch strip is a 1200×100 LCD split into six 200×100 segments, one per encoder (dial). Each segment renders either a layout (title + image + value components composed per Elgato's rules) or defers to a full-strip background that shows through all six segments as one continuous ribbon.
+
+Streamdeck-mcp gives you two levers for each dial:
+1. **Action UUID variant** (the `encoder_layout` field on `streamdeck_write_page`) — static choice made at authoring time.
+2. **Per-dial imagery** (the `icon_path` and `strip_background_path` fields) — the pixels that render in whichever layout slots the chosen UUID exposes.
+
+## Built-in layouts
+
+| Layout | Components | `setFeedback` keys (live-channel, Phase 2) | Phase 1 rendering |
+|---|---|---|---|
+| **(default)** — no `encoder_layout` set | Elgato's default composition (icon overlay + title) with full-strip background show-through | N/A (default composition) | ✅ Renders correctly. Best pick for themed cohesive decks. |
+| **`$X1`** | title + centered icon | `title`, `icon` | ✅ Renders correctly. Clean look for toggle-style dials. |
+| **`$A0`** | title + full-width canvas + small canvas overlay | `title`, `full-canvas`, `canvas` | ✅ Renders correctly. Good for splash art, album covers, per-dial images. |
+| **`$A1`** | title + icon + numeric value | `title`, `icon`, `value` | ⚠️ Value slot empty in Phase 1 (no setFeedback). |
+| **`$B1`** | title + icon + value + progress bar | `title`, `icon`, `value`, `indicator` | ⚠️ Value and bar empty in Phase 1. |
+| **`$B2`** | title + icon + value + gradient bar | `title`, `icon`, `value`, `indicator` | ⚠️ Value and bar empty in Phase 1. |
+| **`$C1`** | title + two icons + two bars | `title`, `icon1`, `icon2`, `indicator1`, `indicator2` | ⚠️ Bars empty in Phase 1. |
+
+**Phase 1 corollary**: `setFeedback` is a live-channel call made by plugin JS. The streamdeck-mcp bundled plugin is currently a pure declarative shell (no JS logic) so it never calls `setFeedback`. The value and indicator slots on `$A1/$B1/$B2/$C1` render empty because nothing populates them. Use those layouts only if the user explicitly accepts the empty slots.
+
+Source: <https://docs.elgato.com/streamdeck/sdk/guides/dials> and <https://docs.elgato.com/streamdeck/sdk/references/touch-strip-layout>.
+
+## Decision tree: which UUID variant?
+
+**On Plus XL, which encoder layout do I pick?**
+
+- Want an immersive themed deck with a single wide background that unifies all six dials? → **Default `.dial`** (omit `encoder_layout`). Generate a 1200×100 PNG via `streamdeck_create_icon(shape="touchstrip", ...)` and set it on one encoder's `strip_background_path`; the show-through shares it across all segments. Pair with per-dial transparent-bg icon overlays (`transparent_bg=True`) on each encoder's `icon_path`.
+- Want per-dial imagery with no show-through? → **`$X1`** (simple icon + title) or **`$A0`** (full-width image + title).
+- Want a visible volume/brightness bar that ticks as the user rotates? → That's a **live-channel feature**. Phase 2. Use `$X1` for now with a volume icon + title, or `$A0` with a custom image; graduate when Phase 2 ships setFeedback wiring.
+
+## Writing per-dial imagery
+
+For an encoder, `streamdeck_write_page` accepts:
+
+```json
+{
+  "controller": "encoder",
+  "key": 0,
+  "title": "Volume",
+  "icon_path": "/path/to/72x72-transparent-icon.png",
+  "strip_background_path": "/path/to/200x100-or-1200x100-bg.png",
+  "encoder_layout": "$X1"
+}
+```
+
+- `icon_path`: 72×72 dial face. Use `transparent_bg=True` when generating the icon so it composes cleanly over the strip background.
+- `strip_background_path`: 200×100 for one segment, OR 1200×100 for the full strip (the default `.dial` UUID shares it across segments via show-through). Use `shape="touchstrip"` on `streamdeck_create_icon` for the 200×100 aspect.
+- `encoder_layout`: omit for the default; set to one of the six codes for a variant.
+
+Fields **must not combine** with `path`/`action_type`/`plugin_uuid`/`action_uuid` — those are for custom actions. The MCP validates this.
+
+## TriggerDescription — the free win
+
+Each encoder action in the bundled plugin manifest declares an `Encoder.TriggerDescription` block. Stream Deck uses its values to tell the user what rotate/push/touch do when they hover or look at their dial stack. Currently the bundled plugin declares empty trigger descriptions (`"Rotate": ""`, etc.) — the Stream Deck app falls back to generic labels.
+
+If you're authoring a deck where a dial's behavior is non-obvious, include descriptive strings in the button spec's `action.settings` or `action.Encoder` payload — the Elgato app surfaces them in the UI. (Exact path depends on how the user's version of the Stream Deck app renders them. Keep them short: "Scene brightness", "Seek track", "Mute on push".)
+
+## Custom layouts (Phase 2+ territory)
+
+Elgato supports custom layout JSON — a file checked into the plugin describing arbitrary text/pixmap/bar/gbar items with rects inside the 200×100 canvas. Streamdeck-mcp doesn't expose this in Phase 1 (the bundled plugin ships only the six built-in variants as static action UUIDs). If a user has a very specific per-dial visual language in mind, the Phase 1 answer is "use the default `.dial` with a custom 1200×100 background PNG" — which handles most visual wishes without custom layout JSON.
+
+Full custom layout schema: <https://docs.elgato.com/streamdeck/sdk/references/touch-strip-layout>.
+
+## Plus-XL-specific quirks
+
+- **The Plus XL has 9 keypad columns, not 8.** `MODEL_LAYOUTS["20GBX9901"]` declares `(9, 4)`. This was corrected in PR #18 after empirical hardware check — writing `position: "8,0"` lands on the rightmost column, not off-grid.
+- **The bundled plugin is required for per-dial imagery to survive restart.** Per-instance `Encoder.Icon` and `Encoder.background` writes get stripped by the Elgato app when quit, unless the action's plugin declares `Controllers: ["Encoder"]`. The streamdeck-mcp plugin does exactly this and nothing else. `streamdeck_write_page` auto-installs it the first time an encoder button needs it; `streamdeck_install_mcp_plugin(force=True)` upgrades after a plugin version bump.
+
+## Sources
+
+- <https://docs.elgato.com/streamdeck/sdk/guides/dials>
+- <https://docs.elgato.com/streamdeck/sdk/references/manifest>
+- <https://docs.elgato.com/streamdeck/sdk/references/touch-strip-layout>

--- a/streamdeck_assets/skill/streamdeck-designer/references/dials-and-touchstrip.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/dials-and-touchstrip.md
@@ -2,7 +2,7 @@
 
 The Stream Deck + XL's touch strip is a 1200×100 LCD split into six 200×100 segments, one per encoder (dial). Each segment renders either a layout (title + image + value components composed per Elgato's rules) or defers to a full-strip background that shows through all six segments as one continuous ribbon.
 
-Streamdeck-mcp gives you two levers for each dial:
+streamdeck-mcp gives you two levers for each dial:
 1. **Action UUID variant** (the `encoder_layout` field on `streamdeck_write_page`) — static choice made at authoring time.
 2. **Per-dial imagery** (the `icon_path` and `strip_background_path` fields) — the pixels that render in whichever layout slots the chosen UUID exposes.
 

--- a/streamdeck_assets/skill/streamdeck-designer/references/dials-and-touchstrip.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/dials-and-touchstrip.md
@@ -51,6 +51,19 @@ For an encoder, `streamdeck_write_page` accepts:
 
 Fields **must not combine** with `path`/`action_type`/`plugin_uuid`/`action_uuid` — those are for custom actions. The MCP validates this.
 
+## Encoder title color is controlled by the layout, not by `title_color`
+
+Phase 1 gotcha: on keypad buttons, `title_color` on the button spec maps to `TitleColor` in the action state and the Stream Deck app renders the title in that color. On encoders, the touchstrip layout's own `color` attribute on the `title` text item wins — `TitleColor` in the action state is ignored at render time. In practice this means encoder titles come out white (the layout default) regardless of what `title_color` you set on the button spec.
+
+The Elgato spec (touch-strip-layout reference) states that when a Text item's `key` equals `"title"`, the property inspector grants users font customization authority, overriding layout-defined color / font / alignment. Our bundled plugin doesn't ship a property inspector, so users can't override it that way either.
+
+Phase 1 workarounds, if white-on-default-bg isn't acceptable:
+1. Bake the title text into the dial's icon PNG (`text="…"` on `streamdeck_create_icon` with a transparent background sized for the dial face). Accept that you lose Elgato's overlay-title dynamic sizing.
+2. Choose backgrounds that look right behind white text.
+3. Skip titles on encoders entirely (set `show_title: false` on the button spec) and rely on the icon to communicate the dial's purpose.
+
+Phase 2 (plugin JS gains `setFeedback`) can call `setFeedback({title: {value: "...", color: "#..."}})` per-instance, closing this gap. Until then, document the limitation rather than try to paper over it.
+
 ## TriggerDescription — the free win
 
 Each encoder action in the bundled plugin manifest declares an `Encoder.TriggerDescription` block. Stream Deck uses its values to tell the user what rotate/push/touch do when they hover or look at their dial stack. Currently the bundled plugin declares empty trigger descriptions (`"Rotate": ""`, etc.) — the Stream Deck app falls back to generic labels.

--- a/streamdeck_assets/skill/streamdeck-designer/references/hardware.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/hardware.md
@@ -1,0 +1,70 @@
+# Stream Deck Hardware Reference
+
+Consult before starting a layout if you don't already know the user's model's tradeoffs. All dimensions come from `MODEL_LAYOUTS` in `profile_manager.py` — if those change, this file is stale. Verify with `streamdeck_read_profiles` which reports the model per profile.
+
+## Models at a glance
+
+| Model | Product ID | Keypad | Encoders | Touchstrip | Best for |
+|---|---|---|---|---|---|
+| Stream Deck Original | 20GBA9901 | 5 × 3 = 15 keys | — | — | Focused action set; tight 3-button-per-context groupings |
+| Stream Deck MK.2 | 20GAA9901 | 5 × 3 = 15 keys | — | — | Same as Original; updated firmware |
+| Stream Deck Mini | 20GAI9501 | 3 × 2 = 6 keys | — | — | Travel; single-purpose dashboards; power user shortcuts |
+| Stream Deck XL | 20GAT9902 | 8 × 4 = 32 keys | — | — | Large action surfaces; clustered workflows; streamer decks |
+| Stream Deck XL rev2 | 20GBA9902 | 8 × 4 = 32 keys | — | — | Same as XL |
+| Stream Deck + XL | 20GBX9901 | 9 × 4 = 36 keys | 6 × 1 | 1200 × 100 | Pro streaming / control surfaces needing continuous values |
+| Stream Deck Neo | 20GBD9901 | 4 × 2 = 8 keys | — | Embedded touchscreen (not yet addressable as separate controller) | Entry-level; always-on clock/weather bar |
+| UI Stream Deck (emulator) | "UI Stream Deck" | 4 × 2 = 8 keys | — | — | Development without physical hardware |
+
+The Plus (non-XL) variant is not yet registered in `MODEL_LAYOUTS`; if the user has one, the profile falls back to the 5×3 grid and you'll need to author for that shape. Consider flagging it so they can open an issue.
+
+## Per-model authoring guidance
+
+### Stream Deck Original / MK.2 (5×3)
+Every key matters. Resist the urge to fill all 15. A good setup is often 8–10 deliberately chosen actions + a "more" button that navigates to a secondary page for overflow. Row 1 (keys 0–4) gets the most-pressed actions. Middle row is fine for "always context" indicators. Bottom row is comfortable for nav + destructive actions (reset, clear).
+
+### Stream Deck XL (8×4)
+Space to organize. Use 4-key-wide clusters — column-groupings around a theme (a column for mic, a column for camera, a column for scenes, a column for effects). The two bottom corners (keys 24 and 31) are the most comfortable physically — reserve them for frequent-plus-meaningful actions.
+
+### Stream Deck + XL (9×4 + 6 encoders + 1200×100 touchstrip)
+The encoders are the magic. Reach for them for **continuous values** (master volume, scene brightness, song position, room temperature, CPU throttle percentage). The keypad stays for discrete actions. The touch strip is six 200×100 segments, one per encoder, that show contextual info for the dial above.
+
+Layout idioms that work:
+- **Encoder-row first**: design the 6 encoders before touching keys. They're the user's most-ergonomic control surface — getting them right anchors the whole deck.
+- **Full-strip background**: use `shape="touchstrip"` to render a single 1200×100 image that spans all six segments (e.g. a wide retrowave skyline). Pair with per-dial transparent icon overlays. See `dials-and-touchstrip.md` for the default vs layout-variant tradeoff.
+- **Keypad as launcher, encoders as adjuster**: presses switch context; rotates refine within context.
+
+### Stream Deck Mini (3×2)
+Six slots. One dedicated dashboard, not a launcher. Examples: a travel deck (airplane mode, VPN, hotspot, flashlight, timer, compass); a focus deck (Pomodoro start, mute all, focus mode on, music play, lights dim, done).
+
+### Stream Deck Neo (4×2)
+Eight keys + a built-in info bar with clock/weather (rendered by the Elgato app, not currently addressable via streamdeck-mcp). Design as if the info bar is always there — don't duplicate clock/weather in your layout. Key layout is cramped enough that you want 4 pressable actions + 4 navigation keys, not 8 flat actions.
+
+## Button indexing
+
+All `key` values are 0-based and row-major (left to right, then top to bottom). For a 5×3 Original:
+
+```
+ 0  1  2  3  4
+ 5  6  7  8  9
+10 11 12 13 14
+```
+
+For an 8×4 XL, the same pattern continues: key 7 is top-right, key 24 is bottom-left, key 31 is bottom-right.
+
+Encoders index 0–5 left-to-right. Touch-strip segments align to their encoders.
+
+If you prefer named positions, pass `"position": "col,row"` instead of `key`. Same semantics, different API.
+
+## Reading the current state
+
+Always begin with `streamdeck_read_profiles`. For each profile you get a name, a `directory_id` (ProfilesV3) or numeric page offsets (ProfilesV2), model info, and per-page metadata.
+
+If you plan to overwrite, run `streamdeck_read_page` on the target to see what's there. If it's empty or already placeholder, write freely. If it's populated with user content, confirm with the user before overwriting.
+
+## Screen vs page terminology
+
+Elgato's "profile" maps to a *context* (e.g. "Streaming", "Coding"). A profile contains **pages** — what the device shows on screen at any moment. Pages inside a profile navigate with the built-in "page.next"/"page.previous" actions. Profiles switch via the profile-switch action (or automatically via "applications to monitor" rules, which streamdeck-mcp doesn't currently write). For most layout tasks, stay inside one profile and one page; add pages only when the user has more than fits.
+
+## Source
+
+Model data comes from `profile_manager.py`'s `MODEL_LAYOUTS` dict and the Elgato SDK's device-type reference at <https://docs.elgato.com/streamdeck/sdk/references/device-types>.

--- a/streamdeck_assets/skill/streamdeck-designer/references/hardware.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/hardware.md
@@ -1,21 +1,26 @@
 # Stream Deck Hardware Reference
 
-Consult before starting a layout if you don't already know the user's model's tradeoffs. All dimensions come from `MODEL_LAYOUTS` in `profile_manager.py` — if those change, this file is stale. Verify with `streamdeck_read_profiles` which reports the model per profile.
+Consult before starting a layout if you don't already know the user's model's tradeoffs. All dimensions come from `MODEL_LAYOUTS` in `profile_manager.py` — if those change, this file is stale. Verify with `streamdeck_read_profiles`, which reports both the raw product ID (`Model`) and a human-readable `ModelName` per profile — always prefer `ModelName` when writing about the user's device (it eliminates any chance of mis-translating the Elgato product code).
 
 ## Models at a glance
 
-| Model | Product ID | Keypad | Encoders | Touchstrip | Best for |
-|---|---|---|---|---|---|
-| Stream Deck Original | 20GBA9901 | 5 × 3 = 15 keys | — | — | Focused action set; tight 3-button-per-context groupings |
-| Stream Deck MK.2 | 20GAA9901 | 5 × 3 = 15 keys | — | — | Same as Original; updated firmware |
-| Stream Deck Mini | 20GAI9501 | 3 × 2 = 6 keys | — | — | Travel; single-purpose dashboards; power user shortcuts |
-| Stream Deck XL | 20GAT9902 | 8 × 4 = 32 keys | — | — | Large action surfaces; clustered workflows; streamer decks |
-| Stream Deck XL rev2 | 20GBA9902 | 8 × 4 = 32 keys | — | — | Same as XL |
-| Stream Deck + XL | 20GBX9901 | 9 × 4 = 36 keys | 6 × 1 | 1200 × 100 | Pro streaming / control surfaces needing continuous values |
-| Stream Deck Neo | 20GBD9901 | 4 × 2 = 8 keys | — | Embedded touchscreen (not yet addressable as separate controller) | Entry-level; always-on clock/weather bar |
-| UI Stream Deck (emulator) | "UI Stream Deck" | 4 × 2 = 8 keys | — | — | Development without physical hardware |
+Elgato's current lineup includes **four distinct SKUs with "+" or "XL" in the name**. Don't conflate them; the key counts and dial counts differ.
 
-The Plus (non-XL) variant is not yet registered in `MODEL_LAYOUTS`; if the user has one, the profile falls back to the 5×3 grid and you'll need to author for that shape. Consider flagging it so they can open an issue.
+| Model name | Product ID | Keypad | Encoders | Touchstrip | Best for |
+|---|---|---|---|---|---|
+| Stream Deck Original | `20GBA9901` | 5 × 3 = 15 keys | — | — | Focused action set; tight 3-button-per-context groupings |
+| Stream Deck MK.2 | `20GAA9901` | 5 × 3 = 15 keys | — | — | Same as Original; updated firmware |
+| Stream Deck Mini | `20GAI9501` | 3 × 2 = 6 keys | — | — | Travel; single-purpose dashboards; power user shortcuts |
+| Stream Deck XL | `20GAT9902` | 8 × 4 = 32 keys | — | — | Large action surfaces; clustered workflows; streamer decks |
+| Stream Deck XL rev2 | `20GBA9902` | 8 × 4 = 32 keys | — | — | Same hardware as XL, updated firmware |
+| **Stream Deck +** (original Plus, 2022) | *ID unknown — see note* | 4 × 2 = 8 keys | **4 × 1** | 800 × 100 | Budget control surface with dials; older/smaller sibling of + XL |
+| **Stream Deck + XL** (the big Plus, 2025) | `20GBX9901` | **9 × 4 = 36 keys** | **6 × 1** | **1200 × 100** | Pro streaming / control surfaces with 6 continuous knobs |
+| Stream Deck Neo | `20GBD9901` | 4 × 2 = 8 keys | — | Embedded clock/weather strip (not separately addressable today) | Entry-level; always-on ambient bar |
+| UI Stream Deck / AI Stream Deck (emulators) | `"UI Stream Deck"`, `"AI Stream Deck"` | 4 × 2 = 8 keys | — | — | Elgato app's virtual companion deck (the app renamed the emulator from "UI" to "AI" in recent builds) |
+
+**The "+ XL" and the original "+" are two different devices, not variants of one.** If `streamdeck_read_profiles` returns `ModelName: "Stream Deck + XL"`, the user has the 36-key / 6-dial version. If it says `Stream Deck +` (the original Plus), it's the 8-key / 4-dial version — half the keys, two-thirds the dials, a narrower touchstrip. Never pattern-match "+ XL" to "Plus (non-XL)."
+
+**Status of the original + in this MCP**: the Elgato-app product ID for the original Stream Deck + has not yet been observed in any profile manifest this project has seen, so it's absent from `MODEL_LAYOUTS`. If `streamdeck_read_profiles` returns a `ModelName` of `Unknown Stream Deck model (<id>)` and the user says they have an original Plus, capture that product ID and add it to `MODEL_LAYOUTS` in a follow-up PR. Until then, profiles on that device will fall back to the 5×3 layout and you'll need to author against the 8-key/4-dial shape explicitly (use `position: "col,row"` with bounds 0–3 / 0–1 for keypad, 0–3 / 0 for encoders).
 
 ## Per-model authoring guidance
 
@@ -24,6 +29,9 @@ Every key matters. Resist the urge to fill all 15. A good setup is often 8–10 
 
 ### Stream Deck XL (8×4)
 Space to organize. Use 4-key-wide clusters — column-groupings around a theme (a column for mic, a column for camera, a column for scenes, a column for effects). The two bottom corners (keys 24 and 31) are the most comfortable physically — reserve them for frequent-plus-meaningful actions.
+
+### Stream Deck + (original Plus, 4×2 + 4 encoders + 800×100 touchstrip)
+Not yet supported — the Elgato-app product ID is unknown to this MCP (no observed profile). If a user has one, author as if it were a 4×2 keypad + 4 encoders + 4-segment touchstrip (each segment 200×100). The design idioms from + XL apply at smaller scale: encoders for continuous values, keypad for discrete actions. Flag to the user that full layout validation against their device isn't possible until the product ID is added to `MODEL_LAYOUTS`.
 
 ### Stream Deck + XL (9×4 + 6 encoders + 1200×100 touchstrip)
 The encoders are the magic. Reach for them for **continuous values** (master volume, scene brightness, song position, room temperature, CPU throttle percentage). The keypad stays for discrete actions. The touch strip is six 200×100 segments, one per encoder, that show contextual info for the dial above.

--- a/streamdeck_assets/skill/streamdeck-designer/references/icons.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/icons.md
@@ -1,0 +1,96 @@
+# Icons
+
+`streamdeck_create_icon` renders icons from the bundled Material Design Icons font (~7400 glyphs, offline, no network). Pass an MDI name and colors; get back a filesystem path to a PNG you hand to `streamdeck_write_page`.
+
+## Calling the tool
+
+```python
+streamdeck_create_icon(
+  icon="mdi:microphone",     # or just "microphone" — the "mdi:" prefix is optional
+  icon_color="#ff4444",      # the glyph
+  bg_color="#ffe0f0",        # the canvas behind (ignored when transparent_bg=True)
+  icon_scale=0.8,            # fraction of canvas the glyph bbox fills
+  shape="button",            # "button" → 72×72, "touchstrip" → 200×100
+  transparent_bg=False,      # True → RGBA canvas, no bg_color fill
+  filename="mic-off"         # optional; auto-generated if omitted
+)
+```
+
+Returns `{"path": "..."}` — pass `result["path"]` as the button's `icon_path`.
+
+## The `icon` vs `text` rule
+
+`icon` and `text` are **mutually exclusive**. The Stream Deck app overlays a button's `title` (set on `streamdeck_write_page`) on top of its image. If you bake text into the PNG *and* set a title, the text doubles up on-screen. For labeled icon buttons:
+
+- Pass only `icon` (or only `text`) to `streamdeck_create_icon`.
+- Put the label in the button's `title` field on `streamdeck_write_page`.
+
+## Scaling
+
+- **Keypad keys with a bottom title**: `icon_scale=0.75-0.85`. Leaves breathing room for the title overlay.
+- **Keypad keys without a title**: `icon_scale=0.9-1.0`. Edge-to-edge.
+- **Encoder dial icons**: `icon_scale=1.0`, `transparent_bg=True`. Matches Elgato's own native icon sizing; composes cleanly over the touchstrip background.
+- **Touchstrip backgrounds**: `shape="touchstrip"`, `icon_scale=0.5-0.8`. Larger canvas (200×100) so you often want less fill.
+
+The `icon_scale` parameter is bounding-box accurate (fraction of canvas filled by the glyph's bbox, not the font em). Default is `1.0`.
+
+## Color strategy as a whole page
+
+Pick one strategy before generating icons; apply it across every icon on the page. Mixing strategies is the single biggest source of "this deck looks random":
+
+**Strategy A — theme-on-neutral**: colored icons, dark or white canvas. Safe default. Works with any palette; high contrast; reads well at arm's length.
+```python
+icon_color="#ff8faa",  # theme pink
+bg_color="#1a1a1a",    # near-black
+```
+
+**Strategy B — neutral-on-theme**: white or black icons, themed canvas. Bolder; brand-forward. Use when the theme colors are the vibe.
+```python
+icon_color="#ffffff",  # white glyph
+bg_color="#ff8faa",    # theme pink canvas
+```
+
+**Strategy C — dual-tone**: alternating pairs (e.g. pink bg + white icon, black bg + pink icon). Creates rhythm across a large grid. Harder to keep coherent — use only if you're intentional about the pattern.
+
+## Fuzzy match on miss
+
+If `icon="mdi:cat-face"` has no exact match, the tool returns suggestions like `["mdi:cat", "mdi:face", "mdi:emoticon-cool"]`. Take the closest one that fits the concept. Don't keep guessing names — the suggestions are already ranked.
+
+## Categorized exemplars
+
+Quick reference to cut down name-search time. All work without `mdi:` prefix.
+
+### Streaming / creator
+`mdi:video-wireless`, `mdi:broadcast`, `mdi:record-circle`, `mdi:microphone`, `mdi:microphone-off`, `mdi:camera`, `mdi:camera-off`, `mdi:monitor-screenshot`, `mdi:account-voice`, `mdi:chat-processing`, `mdi:twitch`, `mdi:youtube`, `mdi:discord`, `mdi:message-text`, `mdi:eye` (viewers), `mdi:heart` (follows), `mdi:currency-usd` (tips), `mdi:pause-circle`, `mdi:skip-next`, `mdi:rewind`
+
+### Dev / coding
+`mdi:github`, `mdi:git`, `mdi:code-braces`, `mdi:code-tags`, `mdi:terminal`, `mdi:docker`, `mdi:bash`, `mdi:cpu-64-bit`, `mdi:memory`, `mdi:bug`, `mdi:test-tube`, `mdi:checkbox-marked-circle`, `mdi:alert-circle`, `mdi:file-code`, `mdi:folder-open`, `mdi:api`, `mdi:server`, `mdi:database`, `mdi:package-variant`, `mdi:language-python`, `mdi:language-typescript`, `mdi:nodejs`
+
+### Music
+`mdi:music`, `mdi:music-note`, `mdi:playlist-music`, `mdi:spotify`, `mdi:apple`, `mdi:play`, `mdi:pause`, `mdi:skip-forward`, `mdi:skip-backward`, `mdi:shuffle-variant`, `mdi:repeat`, `mdi:volume-high`, `mdi:volume-medium`, `mdi:volume-low`, `mdi:volume-off`, `mdi:headphones`, `mdi:microphone-variant`
+
+### Home / IoT
+`mdi:lightbulb`, `mdi:lightbulb-on`, `mdi:lightbulb-off`, `mdi:ceiling-light`, `mdi:lamp`, `mdi:thermometer`, `mdi:thermostat`, `mdi:fan`, `mdi:air-conditioner`, `mdi:garage`, `mdi:door`, `mdi:door-open`, `mdi:lock`, `mdi:lock-open`, `mdi:camera-outline`, `mdi:motion-sensor`, `mdi:home-automation`, `mdi:home`, `mdi:power`
+
+### System / OS
+`mdi:apple-keyboard-command`, `mdi:apple-keyboard-option`, `mdi:apple-keyboard-control`, `mdi:apple-keyboard-shift`, `mdi:monitor`, `mdi:laptop`, `mdi:cellphone`, `mdi:wifi`, `mdi:wifi-off`, `mdi:bluetooth`, `mdi:battery`, `mdi:volume-high`, `mdi:brightness-6`, `mdi:weather-sunny`, `mdi:weather-night`
+
+### UI / actions
+`mdi:cog`, `mdi:account`, `mdi:magnify`, `mdi:plus`, `mdi:minus`, `mdi:check`, `mdi:close`, `mdi:content-copy`, `mdi:content-paste`, `mdi:arrow-left`, `mdi:arrow-right`, `mdi:chevron-left`, `mdi:chevron-right`, `mdi:dots-horizontal`, `mdi:refresh`, `mdi:reload`, `mdi:star`, `mdi:bookmark`, `mdi:pin`, `mdi:eye`, `mdi:eye-off`
+
+### Emotive / aesthetic
+`mdi:heart`, `mdi:star`, `mdi:sparkles`, `mdi:emoticon`, `mdi:fire`, `mdi:flash`, `mdi:crown`, `mdi:diamond`, `mdi:shield`, `mdi:trophy`, `mdi:rocket`, `mdi:palette`, `mdi:paintbrush`
+
+## When nothing fits
+
+MDI is wide (~7400 glyphs) but not infinite. If the exact concept isn't there:
+
+- Try synonyms — "light" vs "lightbulb" vs "lamp" vs "illuminance"; "volume" vs "speaker" vs "audio".
+- Fall back to `text="XYZ"` for a short text icon (but remember: the title overlay still applies, so use text icons only when the button has no title).
+- For branded services that aren't in MDI (Adobe, Figma, specific games), a text-based icon or a custom PNG is the answer — create the PNG separately and pass its path as `icon_path` directly, skipping `streamdeck_create_icon`.
+
+## Sources
+
+- MDI is bundled via `materialdesignicons-webfont.ttf` + `mdi-meta.json` in `streamdeck_assets/`.
+- License: Apache 2.0 (MDI-LICENSE in `streamdeck_assets/`).
+- Full MDI catalog: <https://pictogrammers.com/library/mdi/>.

--- a/streamdeck_assets/skill/streamdeck-designer/references/integrations.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/integrations.md
@@ -1,0 +1,315 @@
+# Integrations
+
+How to wire Stream Deck buttons to real services in Phase 1 (static authoring, no ongoing Claude connection). The common shape:
+
+1. Figure out how to invoke the service from a shell command (curl, CLI, native scripting).
+2. Bake that invocation into a script via `streamdeck_create_action`.
+3. Store credentials in `~/StreamDeckScripts/.env`; source it in each generated script.
+
+Below: per-service patterns. Each one names the companion MCP to prefer for authoring-time discovery (if the user has it installed), the shell-script shape to generate, and what goes in `.env`.
+
+## The `.env` pattern (universal)
+
+All integrations follow this pattern for secrets:
+
+**`~/StreamDeckScripts/.env`** (created once, user-maintained):
+
+```bash
+# Philips Hue
+HUE_BRIDGE_IP=192.168.1.5
+HUE_API_KEY=XYZ-your-long-token-here
+
+# OBS (obs-websocket v5)
+OBS_HOST=127.0.0.1
+OBS_PORT=4455
+OBS_PASSWORD=your-websocket-password
+
+# Home Assistant
+HA_URL=http://homeassistant.local:8123
+HA_TOKEN=your-long-lived-access-token
+
+# Spotify (via spotipy)
+SPOTIFY_CLIENT_ID=...
+SPOTIFY_CLIENT_SECRET=...
+SPOTIFY_REDIRECT_URI=http://localhost:8888/callback
+
+# Twitch
+TWITCH_OAUTH=oauth:your-token
+TWITCH_CHANNEL=yourchannel
+```
+
+**Every generated script sources it**:
+
+```bash
+#!/bin/bash
+set -a
+source "$HOME/StreamDeckScripts/.env"
+set +a
+# ... command using $VAR_NAME variables
+```
+
+Tell the user where `.env` lives, which vars they need to fill in, and that the file is never logged or transmitted. If they're on 1Password CLI or the macOS Keychain, flag that as an alternative and offer to show them the pattern — but `.env` is the default.
+
+---
+
+## Philips Hue
+
+**If a Hue MCP is available in this session**: use it to enumerate bridges, rooms, scenes, and light groups. The goal is that buttons reference the user's *actual* scene names — not placeholders.
+
+**If not**: ask the user for their Hue Bridge IP (on their local network) and their API key. Generate the key via the [Hue CLIP API discovery flow](https://developers.meethue.com/develop/get-started-2/) if they don't have one (they press a physical button on the bridge, then curl `/api`).
+
+### Shell script shape
+
+**Activate a scene**:
+
+```bash
+#!/bin/bash
+set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+curl -s "http://$HUE_BRIDGE_IP/api/$HUE_API_KEY/groups/0/action" \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{"scene": "SCENE_ID_HERE"}' > /dev/null
+```
+
+Scene IDs come from `GET /api/$HUE_API_KEY/scenes` — enumerate them at authoring time via the Hue MCP (or have the user curl once and paste you the list).
+
+**Toggle a room's lights on/off**:
+
+```bash
+#!/bin/bash
+set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+curl -s "http://$HUE_BRIDGE_IP/api/$HUE_API_KEY/groups/1/action" \
+  -X PUT -d '{"on": true}' > /dev/null   # or false
+```
+
+**Set brightness (0–254)**:
+
+```bash
+curl -s "http://$HUE_BRIDGE_IP/api/$HUE_API_KEY/groups/1/action" \
+  -X PUT -d '{"bri": 200}' > /dev/null
+```
+
+On Plus XL you'd want the dial to adjust this value — but dial rotation events land in Phase 2. For now, make discrete brightness presets (25%, 50%, 100%) as separate buttons.
+
+### Icons to reach for
+
+`mdi:lightbulb`, `mdi:lightbulb-on`, `mdi:lightbulb-off`, `mdi:ceiling-light`, `mdi:lamp`, `mdi:palette` (for scenes), `mdi:brightness-6` (brightness).
+
+---
+
+## OBS (obs-websocket v5)
+
+**If an OBS MCP is available**: use it to discover scenes, sources, audio inputs, and studio/program mode state.
+
+**If not**: user needs obs-websocket v5 enabled in OBS (Tools → WebSocket Server Settings; set password). Then use `obs-cli` (Rust, `cargo install obs-cli`) or `obs-websocket-py` for shell scripting. `obs-cli` is simpler.
+
+### Shell script shape (using `obs-cli`)
+
+Install `obs-cli` once, configure via `~/.config/obs-cli/config.yaml` with your websocket host/port/password.
+
+**Switch to a scene**:
+
+```bash
+#!/bin/bash
+obs-cli scene current "Starting Soon"
+```
+
+**Toggle mute on an audio source**:
+
+```bash
+obs-cli audio toggle "Mic/Aux"
+```
+
+**Start / stop stream**:
+
+```bash
+obs-cli stream start
+obs-cli stream stop
+```
+
+**Start / stop recording**:
+
+```bash
+obs-cli record start
+obs-cli record stop
+```
+
+If the user won't install `obs-cli`, use `curl` to the websocket upgrade endpoint — but this requires auth handshake code and is a poor fit for a one-line shell script. Recommend `obs-cli`.
+
+### Icons to reach for
+
+`mdi:video-wireless`, `mdi:broadcast`, `mdi:record-circle`, `mdi:monitor-screenshot`, `mdi:video-switch`, `mdi:microphone`, `mdi:microphone-off`, `mdi:camera`, `mdi:camera-off`.
+
+---
+
+## Home Assistant
+
+**If a Home Assistant MCP is available**: use it to discover entities, scenes, scripts, automations. This is the ideal case — HA has hundreds of entities even in a small house, and picking the right ones by hand is tedious.
+
+**If not**: user provides the URL + a long-lived access token (Profile → Security → Long-Lived Access Tokens).
+
+### Shell script shape
+
+Home Assistant uses REST with bearer auth:
+
+**Call a service** (e.g. activate a scene, run a script):
+
+```bash
+#!/bin/bash
+set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+curl -s -X POST "$HA_URL/api/services/scene/turn_on" \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "scene.evening_chill"}' > /dev/null
+```
+
+**Toggle an entity**:
+
+```bash
+curl -s -X POST "$HA_URL/api/services/light/toggle" \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_id": "light.living_room"}' > /dev/null
+```
+
+**Run a script or automation**:
+
+```bash
+curl -s -X POST "$HA_URL/api/services/script/turn_on" \
+  -H "Authorization: Bearer $HA_TOKEN" \
+  -d '{"entity_id": "script.morning_routine"}' > /dev/null
+```
+
+### Icons
+
+`mdi:home`, `mdi:home-automation`, `mdi:lightbulb`, `mdi:thermostat`, `mdi:door`, `mdi:lock`, `mdi:motion-sensor`, `mdi:robot-vacuum`.
+
+---
+
+## Spotify
+
+**If a Spotify MCP is available**: use it for current-track reads and playback control discovery.
+
+**If not**: Python with `spotipy` is the simplest path. Requires a Spotify developer app (free) and a one-time OAuth flow to get a refresh token. The generated scripts use `spotipy` to issue playback commands.
+
+One-time setup:
+1. User registers a dev app at <https://developer.spotify.com/dashboard>, gets Client ID + Client Secret.
+2. Puts them in `.env` as `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REDIRECT_URI=http://localhost:8888/callback`.
+3. Runs an auth flow script once (you can generate it) that opens the browser, captures the redirect, saves the refresh token to `~/.cache-spotipy` or similar.
+
+### Shell script shape
+
+Each action is a small Python wrapper:
+
+```bash
+#!/bin/bash
+set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+python3 -c "
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(scope='user-modify-playback-state'))
+sp.next_track()
+"
+```
+
+Verbs: `sp.next_track()`, `sp.previous_track()`, `sp.pause_playback()`, `sp.start_playback()`, `sp.start_playback(context_uri='spotify:playlist:...')`, `sp.volume(50)`.
+
+This requires `spotipy` installed in the user's Python. Flag that during authoring.
+
+### Icons
+
+`mdi:play`, `mdi:pause`, `mdi:skip-next`, `mdi:skip-previous`, `mdi:spotify`, `mdi:music`, `mdi:playlist-music`, `mdi:shuffle-variant`, `mdi:repeat`.
+
+---
+
+## Twitch
+
+**If a Twitch MCP is available**: use it to query channel state, viewer count, recent follows.
+
+**If not**: for chat automation the easiest path is `twitch-cli` (official) or curl to the Helix API with an OAuth token.
+
+### Shell script shape
+
+**Send a chat message** (requires OAuth token with `chat:edit` scope):
+
+```bash
+#!/bin/bash
+set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+# Use twitch-cli:
+twitch chat send-message --from-user yourbot --to-channel "$TWITCH_CHANNEL" --message "Welcome to the stream!"
+```
+
+**Run a command shortcut via IRC** (alternative path using curl + IRC gateway is more complex; prefer twitch-cli).
+
+**Toggle chat mode** (emote-only, followers-only) uses the Helix `PATCH /helix/chat/settings` endpoint.
+
+### Icons
+
+`mdi:twitch`, `mdi:chat`, `mdi:message-text`, `mdi:account-group`, `mdi:heart` (followers), `mdi:currency-usd` (bits/tips), `mdi:eye` (viewers).
+
+---
+
+## Shell / terminal / CLI
+
+The simplest category. Any shell command becomes an action directly:
+
+```python
+streamdeck_create_action(
+  name="Open Terminal in Project",
+  command='open -a "Terminal" /path/to/project',
+)
+```
+
+Common shapes:
+
+- **Open a file/folder**: `open /path/to/thing`
+- **Run a build**: `cd /path/to/repo && npm run build`
+- **Invoke a dev server**: `cd /repo && npm run dev`
+- **Run a custom script in the repo**: `cd /repo && ./scripts/do-thing.sh`
+- **Send keyboard shortcut via AppleScript** (macOS): `osascript -e 'tell application "System Events" to keystroke "s" using {command down}'`
+
+For clipboard or `pbcopy`/`pbpaste` automation, just chain shell:
+
+```bash
+echo "$MY_STRING" | pbcopy
+```
+
+### Icons
+
+`mdi:terminal`, `mdi:console`, `mdi:bash`, `mdi:folder-open`, `mdi:code-tags`, `mdi:play-circle`, `mdi:power`.
+
+---
+
+## Browser URLs
+
+```python
+streamdeck_create_action(
+  name="Open GitHub PRs",
+  command='open "https://github.com/verygoodplugins/streamdeck-mcp/pulls"',
+)
+```
+
+Simple and reliable. For multi-URL scripts, chain with `&&` or list separately; Stream Deck fires them sequentially.
+
+### Icons
+
+Per-service: `mdi:github`, `mdi:gitlab`, `mdi:slack`, `mdi:linear`, `mdi:figma`, `mdi:notion`, `mdi:world` (generic web), `mdi:link`.
+
+---
+
+## When you hit a service with no clean shell path
+
+Some services (Adobe apps, proprietary desktop tools, games) are hostile to shell automation. Options, in order of preference:
+
+1. Check if they have a URL scheme (`adobe://`, `figma://`, etc.) — a one-line `open` works.
+2. Check if they have a CLI (`figma-cli`, etc.).
+3. Use AppleScript on macOS (`osascript -e 'tell application "..."'`).
+4. Use `osascript` to send keystrokes as a last resort (fragile — breaks if the target app's UI changes).
+5. Tell the user: "I can't wire [tool] via shell reliably — would you like to set up a keyboard shortcut in [tool] and have the button send that shortcut?" Then use `osascript` to send the keystroke. This is the most reliable fallback.
+
+## Credential hygiene
+
+- **Never** bake a credential inline into a shell script.
+- **Never** log a credential (no `echo $TOKEN`, no `set -x`).
+- **Never** commit `.env` to a repo (user should `echo ".env" >> ~/StreamDeckScripts/.gitignore` if they're tracking that directory).
+- For production-level secrecy, suggest the macOS Keychain (`security find-generic-password`) or 1Password CLI (`op read`) as alternatives to `.env`.

--- a/streamdeck_assets/skill/streamdeck-designer/references/patterns.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/patterns.md
@@ -1,0 +1,155 @@
+# Deck Patterns
+
+Starter specs for common deck archetypes. These aren't copy-paste templates — they're starting shapes you adapt to the user's real integrations, hardware, and preferences. Every user's deck looks different even if they started from the same pattern.
+
+## 1. Streamer deck (Plus XL, hello-kitty theme)
+
+See `assets/recipes/streamer-hello-kitty.json` for the fully-baked JSON equivalent of this pattern.
+
+**Hardware**: Plus XL (9×4 keys + 6 dials + touchstrip).
+**Theme**: Kawaii (pink/white), Strategy A.
+**Integrations**: OBS, Hue, Twitch.
+
+**Encoders (top priority — these are the continuous controls)**:
+- Dial 0: Master volume (icon: `mdi:volume-high`). Rotate for volume, push for mute. *Note: in Phase 1 the volume value won't update live; the dial is a launch point, not a live display.*
+- Dial 1: Mic volume (`mdi:microphone`).
+- Dial 2: Scene brightness via Hue (`mdi:lightbulb-on`).
+- Dial 3: Chat scroll (`mdi:chat`). Push to clear recent.
+- Dial 4: Alerts volume (`mdi:heart`).
+- Dial 5: Master brightness (`mdi:brightness-6`).
+
+**Touchstrip**: single 1200×100 pink-gradient background spanning all six segments. Each dial icon is `transparent_bg=True`, 72×72, composing cleanly.
+
+**Keypad row 0 (scene switches)**:
+- Keys 0–4: scenes (Starting Soon, Just Chatting, Gameplay, BRB, End). Each uses `obs-cli scene current <name>`.
+- Key 5: Go Live (record + stream toggle, combines `obs-cli stream start` and `obs-cli record start`).
+- Keys 6–8: chat shortcuts (welcome, lurk command, schedule).
+
+**Keypad row 1 (mic/camera/sources)**:
+- Keys 9–10: mic / camera toggles (`obs-cli audio toggle "Mic/Aux"`, `obs-cli audio toggle "Camera"`).
+- Keys 11–13: scene sources (game capture, browser source, alerts overlay).
+- Keys 14–17: Hue scenes (Chill, Focus, Stream, Break).
+
+**Keypad row 2 (effects / alerts)**:
+- Keys 18–23: sound effects (via `afplay /path/to/sound.wav` on macOS or equivalent).
+- Keys 24–26: alerts / overlays toggles.
+
+**Keypad row 3 (utilities / navigation)**:
+- Keys 27–29: browser URLs (Twitch dashboard, OBS Studio, Discord).
+- Keys 30–31: volume presets or meta actions (all sources muted, emergency back to Starting Soon).
+- Keys 32–35: nav keys (page next/prev, or profile switch).
+
+This is a starting shape. Adapt: drop rows the user doesn't need; add sound effects as they name them; re-color based on their exact reference.
+
+## 2. Per-repo dev deck (XL, Nordic theme)
+
+See `assets/recipes/dev-nordic.json` for the JSON equivalent.
+
+**Hardware**: XL (8×4).
+**Theme**: Nordic, Strategy A.
+**Integrations**: GitHub, shell, browser, terminal.
+
+Before authoring, examine the user's repo. Key signals:
+- `package.json` scripts → buttons for `dev`, `build`, `test`, `lint`, `deploy`.
+- `Makefile` targets → buttons for each.
+- `pyproject.toml` entry points → buttons for common dev commands.
+- `.github/workflows/` → CI status links.
+- Presence of Docker / docker-compose → start/stop containers.
+
+**Column 0 (build/run)**:
+- Key 0: `npm run dev` (or equivalent). Icon: `mdi:play-circle`.
+- Key 8: `npm run build`. Icon: `mdi:package-variant`.
+- Key 16: `npm test`. Icon: `mdi:test-tube`.
+- Key 24: `npm run lint`. Icon: `mdi:check-circle`.
+
+**Column 1 (git / GitHub)**:
+- Key 1: Open GitHub PRs page. Icon: `mdi:github`.
+- Key 9: Open current branch on GitHub. Icon: `mdi:source-branch`.
+- Key 17: Open Actions / CI. Icon: `mdi:robot`.
+- Key 25: Open Issues. Icon: `mdi:bug`.
+
+**Column 2 (env)**:
+- Key 2: Docker up. Icon: `mdi:docker`.
+- Key 10: Docker down.
+- Key 18: Clear logs.
+- Key 26: Clear cache.
+
+**Columns 3–6**: per-service or per-module shortcuts (specific to the repo).
+
+**Column 7 (terminal/editor)**:
+- Key 7: Open in VSCode (`code /path/to/repo`).
+- Key 15: Open Terminal at repo (`open -a Terminal /path/to/repo`).
+- Key 23: Open `.env` or config file.
+- Key 31: Switch to dev profile (meta nav).
+
+Dev decks benefit from per-repo pages — give each repo its own page, navigate with `page.next`/`page.previous`.
+
+## 3. Music-player deck (Original 5×3, retrowave theme)
+
+See `assets/recipes/music-retrowave.json` for the JSON equivalent.
+
+**Hardware**: Original (5×3, 15 keys). No encoders.
+**Theme**: Retrowave, Strategy B (neon on midnight).
+**Integrations**: Spotify (via spotipy) or Apple Music (via `osascript`).
+
+**Row 0 (playback)**:
+- Key 0: Previous track. Icon: `mdi:skip-previous`, color `#00f5ff` on `#1a1a2e`.
+- Key 1: Play / Pause. Icon: `mdi:play-pause`.
+- Key 2: Next track. Icon: `mdi:skip-next`.
+- Key 3: Shuffle toggle. Icon: `mdi:shuffle-variant`.
+- Key 4: Repeat toggle. Icon: `mdi:repeat`.
+
+**Row 1 (volume / mood presets)**:
+- Key 5: Volume down 10%. Icon: `mdi:volume-low`.
+- Key 6: Volume up 10%. Icon: `mdi:volume-high`.
+- Key 7: Chill playlist. Icon: `mdi:music-note-eighth`.
+- Key 8: Focus playlist. Icon: `mdi:headphones`.
+- Key 9: Party playlist. Icon: `mdi:party-popper`.
+
+**Row 2 (discovery / meta)**:
+- Key 10: Show current track in Spotify (`open -a Spotify`).
+- Key 11: Save track to library. Icon: `mdi:heart`.
+- Key 12: Queue this track. Icon: `mdi:playlist-plus`.
+- Key 13: Open Spotify radio from current artist.
+- Key 14: Mute system audio.
+
+Volume presets work well because Phase 1 can't render a live volume bar — discrete bumps are more legible as buttons than as a "virtual dial."
+
+## 4. Home-control deck (XL, Nature theme)
+
+**Hardware**: XL (8×4) or Plus XL.
+**Theme**: Nature / Forest, Strategy A.
+**Integrations**: Home Assistant (preferred via HA MCP) or Hue direct.
+
+**Organize by room, one row per room**:
+- Row 0: Living room — lights on/off, scene selector (chill/movie/bright), TV toggle.
+- Row 1: Kitchen — lights, appliances, radio.
+- Row 2: Bedroom — lights, fan, alarm.
+- Row 3: House-wide — "all off", "goodnight scene", "arrive home", security toggles.
+
+**Plus XL adds**: encoders for continuous values — master brightness, thermostat setpoint, fan speed, music volume, blind position.
+
+## 5. Claude-companion deck (Plus XL, Terminal theme) — static parts only
+
+This pattern looks ahead to Phase 2 but ships Phase 1 compatible.
+
+**Hardware**: Plus XL.
+**Theme**: Terminal (CRT green), Strategy B.
+**Integrations**: shell (Claude Desktop, Claude Code launch, terminal open).
+
+**Encoders**: reserved for Phase 2 (agent hyperparameters). In Phase 1, label them "Reserved" with placeholder icons, or use them for generic system volume/brightness.
+
+**Keys**: launch Claude Code in specific projects, open terminal, quick commands, clipboard actions. The real "Claude companion" features (ambient status, press-to-answer, thinking indicator) wait for Phase 2.
+
+## Composing patterns together
+
+Real users don't fit one pattern perfectly. A streamer who codes wants a streamer deck *and* a dev deck — on two profiles, navigable via the profile-switch action. A musician/dev wants music controls mixed into their dev deck.
+
+The skill's job is to mix these thoughtfully:
+- Don't squash two full patterns onto one page — it becomes busy.
+- Do pick the most-used 60% of each and put them on separate pages.
+- Do use a **consistent theme across all pages** even if the pages differ functionally. The theme is what makes the whole device feel like it's the user's, not a demo.
+
+## Asking the user what to include
+
+When a pattern has more options than the hardware can fit, always ask. "I have room for 15 keys on your Original. Streamer decks typically want: [top 10]. What else from these: [next 10]?" The user picks; you author. Don't silently drop or add.

--- a/streamdeck_assets/skill/streamdeck-designer/references/sdk-primer.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/sdk-primer.md
@@ -1,0 +1,152 @@
+# Stream Deck SDK primer — hot-path facts
+
+This is the thin slice of the Elgato Stream Deck SDK that agents use on nearly every authoring turn. Everything else lives at `docs.elgato.com/streamdeck/sdk/` (see `sdk-urls.md` for the full index) or Context7 under library `/websites/elgato_streamdeck_sdk`. Use this file first, then look deeper.
+
+The facts here are verbatim from the SDK docs. Do not paraphrase them when emitting to the user — copy the grammar exactly.
+
+## Deep linking
+
+Deep links let a button (or any caller) send a message to a running Stream Deck plugin. The Elgato desktop app intercepts the URL scheme.
+
+### URL grammar
+
+```
+streamdeck://plugins/message/<PLUGIN_UUID>[path][?query][#fragment]
+```
+
+- `streamdeck://plugins/message/` — fixed scheme prefix.
+- `<PLUGIN_UUID>` — required. The target plugin's UUID (e.g. `com.elgato.wavelink`, `com.elgato.hello-world`).
+- `[path]` — optional. An action path inside the plugin (e.g. `/hello`, `/auth`).
+- `[?query]` — optional. Query-string params for the plugin. Reserved key: `streamdeck=hidden` makes the link *passive* (see below).
+- `[#fragment]` — optional. Fragment identifier (e.g. `#waving`).
+
+Full example: `streamdeck://plugins/message/com.elgato.hello-world/hello?name=Elgato#waving`
+
+### Active vs passive
+
+| | Active | Passive |
+|---|---|---|
+| Default behavior | Brings the Stream Deck window to the foreground | Stays in the background |
+| Configuration | Default | Add `?streamdeck=hidden` |
+| Minimum Stream Deck version | 6.5 | 7.0 |
+| Typical use | OAuth flows, any interaction needing focus | Background IPC, port exchange, setup |
+
+### Limits and constraints
+
+- Deep-link messages must stay under **2,000 characters**. For larger payloads use a WebSocket connection.
+- Deep-links are **local-only** — you cannot trigger them from remote sources.
+- Some OAuth providers don't accept custom URL schemes. In that case use the redirect proxy: `https://oauth2-redirect.elgato.com/streamdeck/plugins/message/<PLUGIN_UUID>` — the proxy forwards the callback as a `streamdeck://...` deep link.
+
+### Wiring into a deck button (Phase 1)
+
+Because this skill authors static profiles (not plugins), a deep-link button is a shell action that invokes `open` on macOS or `start` on Windows:
+
+```bash
+#!/bin/bash
+open 'streamdeck://plugins/message/com.elgato.wavelink/settings'
+```
+
+Pass that through `streamdeck_create_action(name="wavelink-settings", command="...")` the same way as any other shell action. The user's Stream Deck app receives the URL and routes it to the named plugin.
+
+**Go deeper** — Context7 query: `"deep linking"` on `/websites/elgato_streamdeck_sdk`. Canonical URL: `https://docs.elgato.com/streamdeck/sdk/guides/deep-linking`.
+
+## manifest.json cheat sheet
+
+`manifest.json` describes a Stream Deck plugin to the Elgato desktop app. Phase 1 of this skill does **not** author plugins — it authors user profiles (a separate artifact). But agents often get manifest questions, and several manifest concepts leak into the profile format (DeviceType IDs, controller types, encoder layout tokens). Read this before speculating.
+
+### Top-level sections (verified from the Manifest TypeScript type)
+
+| Key | Purpose |
+|---|---|
+| `UUID` | Unique plugin ID (e.g. `com.elgato.hello-world`). Also used in deep-link URLs. |
+| `Name`, `Version`, `Author`, `Description`, `Icon` | Plugin metadata. |
+| `Actions[]` | The actions the plugin exposes (Keypad/Encoder). Each has its own UUID, States, Controllers, PropertyInspectorPath. |
+| `CodePath` (+ `CodePathMac`, `CodePathWin`) | Entry-point script the desktop app launches. |
+| `SDKVersion` | `2` or `3`. |
+| `Software.MinimumVersion` | Minimum Stream Deck app version: one of `"6.4"`…`"7.1"`. |
+| `OS[]` | Platform list with `Platform` (`"mac"` \| `"windows"`) and `MinimumVersion`. |
+| `Nodejs` | `{ Version: "20" \| "24", Debug?, GenerateProfilerOutput? }` — required when the plugin is Node-based. |
+| `Profiles[]` | Pre-defined profiles the plugin installs (each with `Name`, `DeviceType` 0–11, `AutoInstall`, `Readonly`, `DontAutoSwitchWhenInstalled`). |
+| `ApplicationsToMonitor` | `{ mac?: string[], windows?: string[] }` — see pitfall below. |
+| `Category`, `CategoryIcon` | Group the plugin in the store UI. |
+| `PropertyInspectorPath` | Plugin-level property inspector file (fallback if action doesn't define one). |
+| `URL`, `SupportURL` | Marketing / help URLs. |
+| `DefaultWindowSize` | Default property-inspector window dimensions. |
+
+Schema URL for JSON-Schema validation / IntelliSense: `https://schemas.elgato.com/streamdeck/plugins/manifest.json`. Put it in `$schema` at the top of `manifest.json`.
+
+### Pitfalls — don't fabricate these
+
+- **The JSON key is `ApplicationsToMonitor`, not `ApplicationMonitoring`.** The docs page is *titled* "Application Monitoring," which tricks both users and agents. The actual manifest field is `ApplicationsToMonitor` with `mac` and `windows` arrays of bundle IDs / executable names. It's a **plugin-side** feature (the plugin's code decides what to do when a monitored app is active/inactive) and has no effect on a static profile authored by streamdeck-mcp.
+- **Encoder layout tokens**: `$X1`, `$A0`, `$A1`, `$B1`, `$B2`, `$C1` are the six built-in touchstrip layouts. The `Encoder.layout` field also accepts a custom `${string}.json` path. See `dials-and-touchstrip.md` for which ones render in Phase 1.
+- **`Controllers`** on an action is a tuple `["Encoder" | "Keypad", ("Encoder" | "Keypad")?]` — the second slot is optional, and an action can be dual-role (keypad + encoder) by listing both.
+- **`Software.MinimumVersion` is a literal union**, not a free-form string. Only the enumerated versions `"6.4"` through `"7.1"` are valid.
+
+**Go deeper** — Context7 query: `"manifest.json schema"` or a specific field name on `/websites/elgato_streamdeck_sdk`. Canonical URL: `https://docs.elgato.com/streamdeck/sdk/references/manifest`.
+
+## WebSocket plugin event glossary
+
+Every plugin event below is a JSON-RPC message the Stream Deck app pushes to the plugin's WebSocket. Phase 1 decks do **not** listen for these (they fire shell commands, not handlers), but agents get asked about them constantly. Names are case-exact. Query Context7 with the event name for the full payload.
+
+### Input events (user action)
+
+| Event | Controller | Purpose |
+|---|---|---|
+| `keyDown` | Keypad | User pressed a keypad button. Payload has `coordinates`, `settings`, `isInMultiAction`, `state`. |
+| `keyUp` | Keypad | User released a keypad button. |
+| `dialDown` | Encoder | User pressed a dial. Distinct from `dialRotate`. |
+| `dialUp` | Encoder | User released a dial. |
+| `dialRotate` | Encoder | User rotated a dial. Payload includes `ticks` (number) and `pressed` (boolean: true if dial was held down *while* rotating). |
+| `touchTap` | Encoder (touchstrip) | User tapped the touchscreen. Payload has `tapPos: [x, y]` and `hold: boolean`. |
+
+**Pitfall — dial events are separate.** `dialRotate` does NOT also fire on press. Press is `dialDown` / `dialUp`. If someone tells you "DialRotate fires on press," they're wrong — correct them with the Elgato docs as evidence.
+
+### Lifecycle events
+
+| Event | Purpose |
+|---|---|
+| `willAppear` | Action instance became visible on the deck (page switch, startup). |
+| `willDisappear` | Action instance left the visible area. |
+| `titleParametersDidChange` | User edited the button's title in the app. |
+| `didReceiveSettings` | Settings for this action instance were updated. |
+| `didReceiveGlobalSettings` | Plugin-wide settings were updated. |
+| `didReceiveDeepLink` | The plugin received a `streamdeck://plugins/message/...` URL (passed in the payload). |
+| `propertyInspectorDidAppear` / `propertyInspectorDidDisappear` | Property inspector UI lifecycle. |
+| `systemDidWakeUp` | Host OS woke from sleep. |
+| `applicationDidLaunch` / `applicationDidTerminate` | Monitored app state changed (requires `ApplicationsToMonitor`). |
+| `deviceDidConnect` / `deviceDidDisconnect` | Stream Deck hardware attach/detach. |
+
+Plugin → app **commands** (setImage, setTitle, setFeedback, setState, sendToPropertyInspector, switchToProfile, openUrl, logMessage, setSettings, etc.) live in the same reference. They are out of scope for Phase 1 (which writes the manifest, not the running plugin), but agents can cite them for user education.
+
+**Go deeper** — Context7 queries: `"<eventName> event payload"` or `"plugin WebSocket commands"` on `/websites/elgato_streamdeck_sdk`. Canonical URL: `https://docs.elgato.com/streamdeck/sdk/references/websocket/plugin`. UI/property-inspector side: `https://docs.elgato.com/streamdeck/sdk/references/websocket/ui`.
+
+## Stream Deck CLI
+
+The `streamdeck` CLI is for plugin developers, not profile authors. Listed here for completeness so agents can answer "what does `streamdeck pack` do?" without guessing.
+
+| Command | Purpose |
+|---|---|
+| `streamdeck config` | Inspect/set CLI configuration. |
+| `streamdeck create` | Scaffold a new plugin project. |
+| `streamdeck dev` | Run a plugin in development mode (hot-reload, logs streamed). |
+| `streamdeck link` | Install a development plugin into the local Stream Deck app. |
+| `streamdeck unlink` | Remove a development plugin. |
+| `streamdeck list` | List installed plugins. |
+| `streamdeck pack` | Package a plugin into a `.streamDeckPlugin` bundle for distribution. |
+| `streamdeck validate` | Validate a plugin's manifest and structure against the SDK schema. |
+| `streamdeck restart` | Restart the Stream Deck app. |
+| `streamdeck stop` | Stop the Stream Deck app. |
+
+None of these are invoked by this skill; `streamdeck_restart_app` (an MCP tool) plays the same role as `streamdeck restart` for the authoring workflow.
+
+**Go deeper** — canonical URL: `https://docs.elgato.com/streamdeck/cli/intro` and per-command pages under `/streamdeck/cli/commands/`. Context7 also has these under library `/websites/elgato_streamdeck_cli` (645 snippets).
+
+## Before you emit an SDK fact
+
+If you catch yourself thinking:
+- "I think I know the deep-link URL format" → verify against this file or Context7 first.
+- "This event name sounds right (`DialRotate`, `onWillAppear`, …)" → verify.
+- "The manifest probably accepts X" → verify.
+- "`setImage` takes a base64 string, right?" → verify.
+
+All of these are the same rule: **do not emit SDK facts you have not just read.** Look it up, then emit.

--- a/streamdeck_assets/skill/streamdeck-designer/references/sdk-urls.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/sdk-urls.md
@@ -1,0 +1,58 @@
+# Stream Deck SDK URL index — fallback for when Context7 is unavailable
+
+Use this file when no `*context7*` tool is available in the session (e.g. the MCP was removed). Pick the closest page to the user's question, `WebFetch` it, and work from that. If Context7 *is* available, prefer it — these URLs are the same pages Context7 indexes, just one round-trip further away.
+
+All URLs below were pulled from `https://docs.elgato.com/sitemap.xml`. The site marks every page `changefreq=weekly`, so content may drift from what this skill was built against.
+
+## Introduction (4 pages) — start here for plugin basics
+
+- `https://docs.elgato.com/streamdeck/sdk/introduction/getting-started` — SDK overview, terminology, the "what is a plugin" primer.
+- `https://docs.elgato.com/streamdeck/sdk/introduction/plugin-environment` — directory layout of a `.sdPlugin`, files the Stream Deck app expects, manifest skeleton.
+- `https://docs.elgato.com/streamdeck/sdk/introduction/your-first-changes` — walkthrough of editing an example plugin.
+- `https://docs.elgato.com/streamdeck/sdk/introduction/distribution` — publishing to the Elgato Marketplace.
+
+## Guides (13 pages) — concepts and recipes
+
+- `https://docs.elgato.com/streamdeck/sdk/guides/actions` — action lifecycle, event handlers, UUID format, `SingletonAction` pattern.
+- `https://docs.elgato.com/streamdeck/sdk/guides/app-monitoring` — `ApplicationsToMonitor` field, `applicationDidLaunch/DidTerminate` events.
+- `https://docs.elgato.com/streamdeck/sdk/guides/deep-linking` — `streamdeck://plugins/message/...` URL grammar, active vs passive, OAuth2 redirect proxy.
+- `https://docs.elgato.com/streamdeck/sdk/guides/devices` — device enumeration, device types (IDs 0–11), `deviceDidConnect/Disconnect` events.
+- `https://docs.elgato.com/streamdeck/sdk/guides/dials` — dial / encoder behavior on Stream Deck +, rotate/press/touch semantics.
+- `https://docs.elgato.com/streamdeck/sdk/guides/i18n` — localization file format, supported locales.
+- `https://docs.elgato.com/streamdeck/sdk/guides/keys` — keypad action states, `setImage`, `setTitle`, multi-action context.
+- `https://docs.elgato.com/streamdeck/sdk/guides/logging` — logger API, log levels, where logs are written on disk.
+- `https://docs.elgato.com/streamdeck/sdk/guides/profiles` — installing and switching profiles from a plugin.
+- `https://docs.elgato.com/streamdeck/sdk/guides/resources` — bundling static assets, i18n, and icons with a plugin.
+- `https://docs.elgato.com/streamdeck/sdk/guides/settings` — per-action settings, global settings, `didReceiveSettings`, `setSettings`.
+- `https://docs.elgato.com/streamdeck/sdk/guides/system` — system-level events (`systemDidWakeUp`, `didReceiveDeepLink`).
+- `https://docs.elgato.com/streamdeck/sdk/guides/ui` — property inspector with `sdpi-components` web-component library.
+
+## References (6 pages) — authoritative schema and API
+
+- `https://docs.elgato.com/streamdeck/sdk/references/manifest` — full `manifest.json` schema (TypeScript type declaration + field-by-field reference). Schema URL: `https://schemas.elgato.com/streamdeck/plugins/manifest.json`.
+- `https://docs.elgato.com/streamdeck/sdk/references/touch-strip-layout` — the six built-in layouts (`$X1`, `$A0`, `$A1`, `$B1`, `$B2`, `$C1`) plus the custom-layout JSON schema.
+- `https://docs.elgato.com/streamdeck/sdk/references/websocket/plugin` — plugin-side WebSocket API: every inbound event (24) and outbound command (22) with TypeScript payloads.
+- `https://docs.elgato.com/streamdeck/sdk/references/websocket/ui` — property-inspector WebSocket API (the UI side of the same protocol).
+- `https://docs.elgato.com/streamdeck/sdk/references/websocket/changelog` — per-version changes to the WebSocket API.
+- `https://docs.elgato.com/streamdeck/sdk/references/changelog` — SDK-wide changelog (v6.4 through v7.1 as of this writing).
+
+## Releases & style guide (2 pages)
+
+- `https://docs.elgato.com/streamdeck/sdk/releases/upgrading/v2` — migration guide from v1 to v2 SDK (breaking changes, codemod notes).
+- `https://docs.elgato.com/streamdeck/sdk/style-guide/linting` — recommended ESLint / TypeScript config for plugin code.
+
+## CLI (11 pages) — for plugin developers
+
+Used when authoring / packaging a `.sdPlugin`, not for profile authoring.
+
+- `https://docs.elgato.com/streamdeck/cli/intro` — installation and overview.
+- `https://docs.elgato.com/streamdeck/cli/commands/config` — CLI configuration.
+- `https://docs.elgato.com/streamdeck/cli/commands/create` — scaffold a new plugin.
+- `https://docs.elgato.com/streamdeck/cli/commands/dev` — run a plugin in development mode.
+- `https://docs.elgato.com/streamdeck/cli/commands/link` — install a dev plugin into the desktop app.
+- `https://docs.elgato.com/streamdeck/cli/commands/unlink` — remove a dev plugin.
+- `https://docs.elgato.com/streamdeck/cli/commands/list` — list installed plugins.
+- `https://docs.elgato.com/streamdeck/cli/commands/pack` — package a plugin for distribution.
+- `https://docs.elgato.com/streamdeck/cli/commands/validate` — validate a plugin's manifest + structure.
+- `https://docs.elgato.com/streamdeck/cli/commands/restart` — restart the Stream Deck app.
+- `https://docs.elgato.com/streamdeck/cli/commands/stop` — stop the Stream Deck app.

--- a/streamdeck_assets/skill/streamdeck-designer/references/themes.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/themes.md
@@ -1,0 +1,118 @@
+# Theme Archetypes
+
+Starter palettes + strategy for common aesthetics. These aren't prescriptive — adapt to the user's exact reference if they give you one. If they just said the theme name, these defaults get you 80% there.
+
+Each archetype lists: the palette (3–5 hex codes), the icon-color strategy (A/B/C as defined in `icons.md`), typography note, and one example MDI glyph + color combo for a "play" button to anchor the style.
+
+## Kawaii / Hello Kitty
+
+Pastel pink-dominant, soft. Reads as cute without being clinical.
+
+```
+Palette:       #ff8faa (primary pink), #ffe0f0 (pale pink), #ffffff (white), #1a1a1a (near-black for contrast)
+Accent:        #ffd700 (gold for emphasis/highlights)
+Strategy:      A (theme-on-neutral) — pink/gold icons on near-white canvases; use Strategy B for 1–2 "hero" buttons in reverse
+Typography:    Default title; `title_color="#1a1a1a"` on pale backgrounds, `#ffffff` on pink
+Example:       icon="mdi:heart", icon_color="#ff8faa", bg_color="#ffe0f0"  — play button equivalent
+```
+
+Good for streamers targeting kawaii/anime communities, casual creators, personal-brand decks. Avoid for technical/corporate contexts unless the user *wants* the contrast.
+
+## Retrowave / Synthwave
+
+Saturated pink + cyan + deep purple, with neon glow. Dark canvases essential — retrowave dies on white.
+
+```
+Palette:       #ff006e (neon pink), #00f5ff (cyan), #7209b7 (deep purple), #1a1a2e (midnight bg), #ffb703 (sun-yellow accent)
+Strategy:      B (neutral-on-theme) — cyan/pink icons on midnight backgrounds; occasional sun-yellow for single "hero" glyphs
+Typography:    `title_color="#00f5ff"` or `#ffb703` on midnight
+Example:       icon="mdi:play", icon_color="#00f5ff", bg_color="#1a1a2e"
+```
+
+Matches music-deck and streamer contexts. The full touchstrip is a canvas for a wide retrowave skyline image (generate it externally, not via MDI).
+
+## Brutalist
+
+High-contrast, minimal color, type-forward. All function, no ornament.
+
+```
+Palette:       #ffffff (white), #000000 (black), #ff0000 (single red accent)
+Strategy:      A (theme-on-neutral) — black icons on white, occasional red for destructive or critical actions
+Typography:    `title_color="#000000"`, larger-than-default `font_size` if possible
+Example:       icon="mdi:play", icon_color="#000000", bg_color="#ffffff"
+```
+
+Good for developer decks, operational dashboards, anyone who wants the opposite of playful.
+
+## Nordic
+
+Cool, muted, gentle. The quiet palette that doesn't fatigue at arm's length.
+
+```
+Palette:       #2e3440 (polar night), #88c0d0 (frost blue), #a3be8c (aurora green), #d8dee9 (snow white), #bf616a (aurora red for warnings)
+Strategy:      A (theme-on-neutral) — frost blue / aurora green icons on polar-night backgrounds
+Typography:    `title_color="#d8dee9"` on dark
+Example:       icon="mdi:play", icon_color="#88c0d0", bg_color="#2e3440"
+```
+
+Excellent default for dev/coding decks. Easy on the eyes, plays well with IDE themes the user is probably already in.
+
+## Terminal
+
+CRT green on black, monospace aesthetic. Dev-heavy.
+
+```
+Palette:       #00ff41 (terminal green), #0a0a0a (near-black), #00ff9c (secondary green), #ff6b35 (error orange)
+Strategy:      B — green glyphs on near-black. No other strategies work here.
+Typography:    `title_color="#00ff41"` on black. Ideally monospace but default font still reads.
+Example:       icon="mdi:terminal", icon_color="#00ff41", bg_color="#0a0a0a"
+```
+
+Ship-of-theseus dev decks, hacker aesthetics, anyone running a `cmatrix` screensaver.
+
+## Nature / Forest
+
+Earth tones, organic. Calming.
+
+```
+Palette:       #2d6a4f (forest green), #d8f3dc (pale sage), #95d5b2 (mid green), #1b4332 (deep green), #ffb703 (sun yellow accent)
+Strategy:      A — forest-green / deep-green icons on pale sage, occasional yellow for emphasis
+Typography:    `title_color="#1b4332"` on pale, `#d8f3dc` on dark
+Example:       icon="mdi:leaf", icon_color="#2d6a4f", bg_color="#d8f3dc"
+```
+
+Home-control decks, outdoor / hobby contexts, anyone who specifically asked for "calming."
+
+## Minimal / Monochrome
+
+No color. Grayscale gradations. Discipline.
+
+```
+Palette:       #ffffff (white), #e5e5e5 (light gray), #a3a3a3 (mid gray), #404040 (dark gray), #0a0a0a (near-black)
+Strategy:      A — single-tone glyphs; vary via bg grays, not glyph color
+Typography:    Subtle; `title_color="#0a0a0a"` on light, `#ffffff` on dark
+Example:       icon="mdi:play", icon_color="#0a0a0a", bg_color="#e5e5e5"
+```
+
+Good when the user says "nothing fancy", "just functional", or doesn't want to think about theme. Falls back well.
+
+## Corporate / Professional
+
+Brand-blue-dominant, business-clean.
+
+```
+Palette:       #0077b6 (corporate blue), #023e8a (deep blue), #caf0f8 (pale blue), #ffffff (white), #ef233c (accent red for alerts)
+Strategy:      A — blue icons on white canvases; reverse for hero buttons
+Typography:    `title_color="#023e8a"`
+Example:       icon="mdi:briefcase", icon_color="#0077b6", bg_color="#ffffff"
+```
+
+Dashboards for work contexts, client-facing decks, demo setups.
+
+## Asking when unclear
+
+If the user named a theme you don't recognize (e.g. "cottagecore", "cyberpunk 2077", a specific anime aesthetic), don't silently map to the closest archetype. Ask: "What's the feel — earthy pastels or harsh neons? Got a reference image?" Theme naming is personal, and the wrong approximation is annoying.
+
+## Typography limits
+
+`streamdeck_write_page`'s button schema exposes `font_size`, `title_color`, `title_alignment`, `show_title`. That's it — no font family selection in Phase 1 (Elgato's default sans-serif is used). Color and placement are your main levers. If a theme depends on a specific font (e.g. retrowave's chrome typography), that typography lives in the *icon PNGs*, not in titles.

--- a/streamdeck_assets/skill/streamdeck-designer/references/troubleshooting.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/troubleshooting.md
@@ -63,7 +63,7 @@ If nothing fits: fall back to `text="XY"` (short text icon) or generate the PNG 
 
 ## "Icon + title text are doubled up"
 
-On-device, a button shows both a bakedin text on the icon PNG *and* a title overlaid at the bottom.
+On-device, a button shows both a baked-in text on the icon PNG *and* a title overlaid at the bottom.
 
 **Cause**: you called `streamdeck_create_icon` with both `icon="mdi:..."` and `text="..."`, or you baked a title into a text-only icon and *also* set the button's `title` field.
 

--- a/streamdeck_assets/skill/streamdeck-designer/references/troubleshooting.md
+++ b/streamdeck_assets/skill/streamdeck-designer/references/troubleshooting.md
@@ -1,0 +1,123 @@
+# Troubleshooting
+
+Symptoms and fixes for common authoring-time failures. If the fix isn't here and the behavior is consistent, it's worth filing an issue — most of these came from real hardware sessions.
+
+## "No Stream Deck profiles found"
+
+`streamdeck_read_profiles` returned nothing or errors.
+
+- **macOS**: profiles live under `~/Library/Application Support/com.elgato.StreamDeck/ProfilesV3/` (preferred) or `ProfilesV2/`. If neither directory exists, the Elgato app hasn't been run on this machine. Ask the user to launch it once.
+- **Windows**: `%APPDATA%\Elgato\StreamDeck\ProfilesV3\`. Same rule.
+- **Empty directories**: the user has the app installed but no profiles created yet. Tell them to create a profile in the Elgato app, then retry.
+- **Permissions**: on macOS Sonoma+, the Elgato app directory sometimes needs explicit Full Disk Access granted to the terminal Claude Code is running from. Symptoms: permission-denied errors reading the profile manifest. Fix: System Settings → Privacy & Security → Full Disk Access → add Terminal (or iTerm, etc.).
+
+## "StreamDeckAppRunningError"
+
+The Elgato desktop app is running, and `streamdeck_write_page` refuses to write.
+
+**Why**: the Elgato app caches every profile in memory and rewrites the on-disk manifests from its snapshot when it quits. Any edit made while the app is running is overwritten the next time it closes.
+
+**Fix**: pass `auto_quit_app=True` to `streamdeck_write_page`. The tool gracefully quits the app (AppleScript first, `killall` fallback), writes the manifest, and then `streamdeck_restart_app` relaunches it.
+
+Don't ask the user to quit manually — always pass the flag.
+
+## "Write succeeded but the deck doesn't show my changes"
+
+`streamdeck_write_page` returned success, but on-device the page looks unchanged.
+
+- Did you call `streamdeck_restart_app` after? The Elgato app reads manifests on launch; without a restart, the old cached layout persists.
+- If you did restart and it's still wrong, read the page back with `streamdeck_read_page` and diff against your spec. If `read_page` shows your new buttons but the device doesn't, the Elgato app may be in a cache-weirdness state — quit it (`killall "Elgato Stream Deck"` or via Activity Monitor) and relaunch.
+- Check that you wrote to the page the *device is currently showing*. A Plus XL might be on page 3 of a profile; writing to page 1 updates page 1, not what's on screen.
+
+## "My encoder icon disappeared after restarting the Elgato app"
+
+Known issue. The Elgato app strips `Encoder.Icon` and `Encoder.background` fields from the manifest unless the action's plugin declares `Controllers: ["Encoder"]`.
+
+**Fix**: make sure the bundled streamdeck-mcp plugin is installed. `streamdeck_write_page` auto-installs it the first time an encoder button references it, but if you wrote an encoder button and the plugin install was skipped or failed, the fields get stripped on the next app quit.
+
+- Verify: check `~/Library/Application Support/com.elgato.StreamDeck/Plugins/io.github.verygoodplugins.streamdeck-mcp.sdPlugin/` exists.
+- Force-install: `streamdeck_install_mcp_plugin(force=True)`.
+- After install, quit and relaunch the Elgato app. Now the stripping stops.
+
+Background: this is PR #20's core finding. Don't spend cycles re-investigating — it's the plugin-declaration issue every time.
+
+## "Encoder layout value/indicator slot is empty"
+
+On-device, a dial using `$A1`/`$B1`/`$B2`/`$C1` shows title + icon but the value number or bar is blank.
+
+**This is expected in Phase 1**, not a bug. Those slots are populated by `setFeedback` calls made by plugin JS, and the bundled plugin doesn't make those calls yet (memory: it's a no-op registration shell). Graduate to Phase 2 (live channel) for live values.
+
+**Workaround in Phase 1**: use `$X1` or `$A0` (title + icon or title + full-canvas; no value slot to be empty). Or use the default `.dial` (no `encoder_layout` field) for the default composition with full-strip show-through.
+
+## "Icon not found" / fuzzy-match suggestions
+
+`streamdeck_create_icon(icon="mdi:cat-face")` returned something like:
+
+```
+{"error": "icon 'mdi:cat-face' not found", "suggestions": ["mdi:cat", "mdi:face", "mdi:emoticon-cool"]}
+```
+
+**Fix**: pick the closest suggestion and retry. MDI's naming is consistent (`kebab-case`, `category-subject`), but exact concept fits aren't always there. Don't keep guessing by typing — the suggestions are ranked by edit distance.
+
+If nothing fits: fall back to `text="XY"` (short text icon) or generate the PNG externally and pass `icon_path` directly on `streamdeck_write_page`.
+
+## "Icon + title text are doubled up"
+
+On-device, a button shows both a bakedin text on the icon PNG *and* a title overlaid at the bottom.
+
+**Cause**: you called `streamdeck_create_icon` with both `icon="mdi:..."` and `text="..."`, or you baked a title into a text-only icon and *also* set the button's `title` field.
+
+**Fix**: pick one. For labeled icon buttons: `icon` param on `create_icon` + `title` field on `write_page`. For text-only buttons: `text` param on `create_icon` + no title on `write_page`.
+
+## "Icon looks too small on the key"
+
+- Check `icon_scale`. Default is `1.0` (edge-to-edge). If you set it lower, revisit. For keypad keys with a bottom title, `0.75`–`0.85` is a good range. For touchstrip segments, `1.0` matches Elgato's native sizing.
+
+## "Button press does nothing on-device"
+
+- Action type wrong: if you used `action_type: "next_page"` but the profile has no next page, it silently fails. Add a page or use a different action.
+- Shell command fails silently: test the generated script directly (`~/StreamDeckScripts/<slug>.sh`) from a terminal. If it errors, check the `.env` file has values, not placeholders.
+- Permissions: macOS sometimes blocks new shell scripts. Right-click the script file, Open With → Terminal, confirm the dialog once. After that, Stream Deck can invoke it.
+
+## "Can't find credentials at button-press time"
+
+Symptoms: the button runs but the integration fails silently (Hue scene doesn't change, OBS command doesn't route, etc.).
+
+- Check `~/StreamDeckScripts/.env` exists and has real values (not `PLACEHOLDER_HUE_KEY`).
+- Check each script sources the env file correctly:
+  ```bash
+  set -a; source "$HOME/StreamDeckScripts/.env"; set +a
+  ```
+- Run the script manually from a terminal: `bash ~/StreamDeckScripts/scene-chill.sh`. If it fails there, fix the env. If it succeeds there but fails from the deck, it's a Stream Deck process-environment issue — ensure the script is using absolute paths and the `set -a; source ...` pattern (which exports the vars into child processes).
+
+## "I need a totally custom icon (not in MDI)"
+
+Stream Deck keys render any 72×72 PNG. Generate your image externally (even a paint app works) and pass its path directly as `icon_path` on `streamdeck_write_page`. Skip `streamdeck_create_icon` for that button.
+
+For dial icons that need to composite over a touchstrip background, the external PNG should be RGBA with transparency.
+
+## "I want live / dynamic behavior"
+
+That's Phase 2. In Phase 1:
+- Don't try to fake live updates with a polling shell script that rewrites the manifest. Manifest rewrites require the Elgato app to be down, so polling at runtime doesn't work.
+- Tell the user what Phase 2 will add (live-channel `setFeedback`, MCP-callback actions, progress bars that actually update) and whether a Phase-1-compatible workaround exists for their specific request.
+
+## "Plugin install failed / permission denied"
+
+`streamdeck_install_mcp_plugin` needs write access to the Elgato Plugins directory:
+- macOS: `~/Library/Application Support/com.elgato.StreamDeck/Plugins/`
+- Windows: `%APPDATA%\Elgato\StreamDeck\Plugins\`
+
+If permission is denied:
+- On macOS, check Full Disk Access (Privacy & Security) for Terminal/iTerm.
+- The Elgato app shouldn't be running during plugin install — pass `auto_quit_app=True` to `streamdeck_write_page` or quit manually first.
+
+## Still stuck
+
+Open an issue at <https://github.com/verygoodplugins/streamdeck-mcp/issues> with:
+- Hardware model + OS.
+- The full error message / unexpected behavior.
+- The `streamdeck_write_page` arguments you used (sanitize any secrets).
+- Output of `streamdeck_read_profiles`.
+
+Most bugs reproduce with those four pieces of info.

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -1383,3 +1383,49 @@ def test_coerce_arguments_leaves_unparseable_values_alone() -> None:
     assert out["icon_scale"] == "pi"
     assert out["auto_quit_app"] == "maybe"
     assert out["buttons"] == "not-json"
+
+
+def test_coerce_arguments_leaves_empty_string_bool_alone() -> None:
+    """Empty strings pass through unchanged — handlers' own default logic
+    (e.g. arguments.get(key, False)) decides what a blank value means
+    rather than this helper eagerly coercing it to False."""
+
+    from profile_server import _coerce_arguments
+
+    out = _coerce_arguments(
+        {"auto_quit_app": "", "clear_existing": ""},
+        bools=("auto_quit_app", "clear_existing"),
+    )
+    assert out["auto_quit_app"] == ""
+    assert out["clear_existing"] == ""
+
+
+def test_install_skill_marks_overwrote_when_target_exists(tmp_path) -> None:
+    """--force is destructive by design (matches argparse help wording).
+    The install() return must flag when it clobbered an existing tree so
+    callers can surface that in UX."""
+
+    import shutil
+
+    import install_skill
+
+    target_parent = tmp_path / "skills"
+    original_skills_root = install_skill.SKILLS_ROOT
+    install_skill.SKILLS_ROOT = target_parent
+    try:
+        # Pre-populate the target so install() has something to overwrite.
+        target = target_parent / install_skill.SKILL_NAME
+        target.mkdir(parents=True)
+        (target / "local-edit.md").write_text("user's own notes")
+
+        result = install_skill.install(force=True)
+        assert result["installed"] is True
+        assert result["overwrote"] is True
+        assert "local edits" in result["message"].lower() or "gone" in result["message"].lower()
+        # The user's file is gone; the bundled SKILL.md is in its place.
+        assert not (target / "local-edit.md").exists()
+        assert (target / "SKILL.md").exists()
+    finally:
+        install_skill.SKILLS_ROOT = original_skills_root
+        if target_parent.exists():
+            shutil.rmtree(target_parent)

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -1196,3 +1196,107 @@ def test_write_page_auto_installs_mcp_plugin_for_layout_variant(
     )
     assert result["mcp_plugin_install"]["installed"] is True
     assert (plugins_dir / PLUGIN_DIR_NAME / "manifest.json").exists()
+
+
+def test_list_profiles_enriches_device_with_model_name(
+    sample_profiles_v3: Path, tmp_path: Path
+) -> None:
+    """streamdeck_read_profiles must surface a human-readable model name alongside
+    the raw Elgato product ID. Without this, LLMs authoring decks can mis-translate
+    product codes and pick the wrong layout — real-world failure mode from Steve's
+    first trial run (20GBX9901 confused with the non-XL Plus)."""
+
+    manager = ProfileManager(
+        profiles_dir=sample_profiles_v3,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    profiles = manager.list_profiles()
+
+    assert len(profiles) == 1
+    device = profiles[0]["device"]
+    # Fixture uses 20GBA9901 (Stream Deck Original)
+    assert device["Model"] == "20GBA9901"
+    assert device["ModelName"] == "Stream Deck Original"
+
+
+def test_list_profiles_marks_unknown_models_clearly(tmp_path: Path) -> None:
+    """Unknown product IDs (e.g. a future Stream Deck SKU or an ID we haven't
+    mapped yet) must produce an explicit 'Unknown Stream Deck model (<id>)'
+    string — never silently fall through to an empty name or raw ID."""
+
+    profiles_dir = tmp_path / "ProfilesV3"
+    profile_dir = profiles_dir / "UNKNOWN.sdProfile"
+    _write_json(
+        profile_dir / "manifest.json",
+        {
+            "Device": {"Model": "20GZ9999", "UUID": "@(1)"},
+            "Name": "Mystery",
+            "Pages": {"Current": None, "Default": None, "Pages": []},
+            "Version": "3.0",
+        },
+    )
+    manager = ProfileManager(
+        profiles_dir=profiles_dir,
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    profiles = manager.list_profiles()
+    assert profiles[0]["device"]["ModelName"] == "Unknown Stream Deck model (20GZ9999)"
+
+
+def test_create_icons_generates_batch_in_one_call(tmp_path: Path) -> None:
+    """Batch icon creation — the primary optimization behind this round of
+    changes. 32-key decks authored with one icon per MCP call timed out in
+    real use; batching closes that gap."""
+
+    manager = ProfileManager(
+        profiles_dir=tmp_path / "profiles",
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    results = manager.create_icons(
+        [
+            {"icon": "mdi:volume-high", "icon_color": "#00ff88", "filename": "b1"},
+            {"icon": "mdi:microphone", "icon_color": "#ff4444", "filename": "b2"},
+            {"text": "GO", "bg_color": "#000000", "text_color": "#ff006e", "filename": "b3"},
+        ]
+    )
+    assert len(results) == 3
+    for r in results:
+        assert "error" not in r
+        assert Path(r["path"]).exists()
+
+
+def test_create_icons_captures_per_spec_errors(tmp_path: Path) -> None:
+    """A single bad spec must not abort the whole batch — record the error in
+    its slot and keep generating the rest. Matches the real-world pattern
+    where one MDI name has a typo out of 30 and the author wants the other 29
+    to land without a retry."""
+
+    manager = ProfileManager(
+        profiles_dir=tmp_path / "profiles",
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    results = manager.create_icons(
+        [
+            {"icon": "mdi:volume-high", "filename": "good_1"},
+            {"icon": "mdi:nonexistent-icon-name-xyz", "filename": "bad"},
+            {"icon": "mdi:microphone", "filename": "good_2"},
+        ]
+    )
+    assert "error" not in results[0]
+    assert "error" in results[1]
+    assert results[1]["spec_index"] == 1
+    assert "error" not in results[2]
+
+
+def test_create_icons_rejects_empty_list(tmp_path: Path) -> None:
+    manager = ProfileManager(
+        profiles_dir=tmp_path / "profiles",
+        scripts_dir=tmp_path / "scripts",
+        generated_icons_dir=tmp_path / "icons",
+    )
+    with pytest.raises(ProfileValidationError):
+        manager.create_icons([])

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -1300,3 +1300,86 @@ def test_create_icons_rejects_empty_list(tmp_path: Path) -> None:
     )
     with pytest.raises(ProfileValidationError):
         manager.create_icons([])
+
+
+def test_coerce_arguments_normalizes_stringified_values() -> None:
+    """MCP clients sometimes stringify typed tool-call arguments in transit
+    (Claude Code's tool-call serialization does this as of April 2026). The
+    server-side coercion must restore booleans, numbers, integers, and JSON
+    arrays from their string forms so downstream handlers see native types."""
+
+    from profile_server import _coerce_arguments
+
+    out = _coerce_arguments(
+        {
+            "page_index": "3",
+            "font_size": "18",
+            "icon_scale": "0.8",
+            "auto_quit_app": "true",
+            "clear_existing": "FALSE",
+            "transparent_bg": "1",
+            "buttons": '[{"key": 0}, {"key": 1}]',
+            "icons": '[{"icon":"mdi:play"}]',
+            "page_name": "Home",  # genuine string — must stay a string
+        },
+        ints=("page_index", "font_size"),
+        nums=("icon_scale",),
+        bools=("auto_quit_app", "clear_existing", "transparent_bg"),
+        arrays=("buttons", "icons"),
+    )
+    assert out["page_index"] == 3
+    assert out["font_size"] == 18
+    assert out["icon_scale"] == 0.8
+    assert out["auto_quit_app"] is True
+    assert out["clear_existing"] is False
+    assert out["transparent_bg"] is True
+    assert out["buttons"] == [{"key": 0}, {"key": 1}]
+    assert out["icons"] == [{"icon": "mdi:play"}]
+    assert out["page_name"] == "Home"
+
+
+def test_coerce_arguments_passes_through_native_types() -> None:
+    """Already-correctly-typed values must round-trip untouched."""
+
+    from profile_server import _coerce_arguments
+
+    out = _coerce_arguments(
+        {
+            "page_index": 3,
+            "icon_scale": 0.8,
+            "auto_quit_app": True,
+            "buttons": [{"key": 0}],
+        },
+        ints=("page_index",),
+        nums=("icon_scale",),
+        bools=("auto_quit_app",),
+        arrays=("buttons",),
+    )
+    assert out["page_index"] == 3
+    assert out["icon_scale"] == 0.8
+    assert out["auto_quit_app"] is True
+    assert out["buttons"] == [{"key": 0}]
+
+
+def test_coerce_arguments_leaves_unparseable_values_alone() -> None:
+    """Invalid strings (not a valid int/float/bool/JSON) stay as-is so the
+    downstream handler's specific error message surfaces to the caller."""
+
+    from profile_server import _coerce_arguments
+
+    out = _coerce_arguments(
+        {
+            "page_index": "not-a-number",
+            "icon_scale": "pi",
+            "auto_quit_app": "maybe",
+            "buttons": "not-json",
+        },
+        ints=("page_index",),
+        nums=("icon_scale",),
+        bools=("auto_quit_app",),
+        arrays=("buttons",),
+    )
+    assert out["page_index"] == "not-a-number"
+    assert out["icon_scale"] == "pi"
+    assert out["auto_quit_app"] == "maybe"
+    assert out["buttons"] == "not-json"


### PR DESCRIPTION
## Summary

Phase 1 of the LLM-as-deck-designer reframe. Ships an **Agent Skill** that teaches Claude how to use the existing MCP tools to author complete, themed, integrated Stream Deck layouts — the kind of deck a user gets from a prompt like "give me a hello-kitty Twitch deck" or "build me a Home Assistant heating controller on my Plus XL." Also lands three code-side fixes surfaced during two real on-device trial runs (one with Steve, one with Jack's own heating setup).

The skill lives at `streamdeck_assets/skill/streamdeck-designer/` and follows the skill-creator convention: `SKILL.md` (≤500 lines) + `references/` (loaded on demand) + `assets/recipes/` (adaptation shapes). Installs to `~/.claude/skills/streamdeck-designer/` via a new `streamdeck-mcp-install-skill` console entry. Non-Claude-Code clients (Claude Desktop, Cursor, ChatGPT-with-MCP) get the same content via a new `design_streamdeck_deck` MCP prompt that mirrors the SKILL.md body.

### What's in the skill

- **SKILL.md** — 10-step authoring loop: inventory hardware first, plan palette before icons, discover integrations at authoring time via companion MCPs, bake into shell scripts, never inline secrets, verify on-device.
- **9 references** loaded on demand:
  - `hardware.md` — every Stream Deck SKU in `MODEL_LAYOUTS` + explicit disambiguation between the four "+ / XL" devices Elgato sells.
  - `dials-and-touchstrip.md` — layout decision tree ($X1/$A0/$A1/$B1/$B2/$C1) with Phase 1 constraints called out.
  - `icons.md` — MDI usage + 30+ categorized exemplars + scaling guidance.
  - `themes.md` — 8 archetypes (kawaii, retrowave, brutalist, nordic, terminal, nature, minimal, corporate) with ready palettes.
  - `integrations.md` — per-service patterns for Hue, OBS, Spotify, Home Assistant, Twitch, shell, browser.
  - `patterns.md` — starter specs for streamer / per-repo dev / music / home-control / companion decks.
  - `troubleshooting.md` — symptoms and fixes.
  - `sdk-primer.md` — hot-path SDK facts (deep-link URL grammar, manifest cheat sheet, WebSocket event glossary, CLI commands).
  - `sdk-urls.md` — full URL index from Elgato's sitemap for `WebFetch` fallback when Context7 isn't available.
- **3 starter recipes**: `streamer-hello-kitty.json` (Plus XL), `dev-nordic.json` (XL), `music-retrowave.json` (Original 5×3).
- **SDK authority routing**: SKILL.md teaches Claude to consult the primer first, Context7 second (`*context7*query-docs*` pattern-match since namespace varies), sitemap + `WebFetch` last. Explicit "red flags" list names common LLM-fabrication temptations (deep-link URL format, event names, manifest fields) and routes each to a lookup step.

### Code-side improvements

1. **`ModelName` enrichment in `streamdeck_read_profiles`** — new `MODEL_NAMES` dict provides human-readable names alongside raw product IDs. Motivated by Steve's first trial run where an LLM confused `20GBX9901` (+ XL) with the original + (non-XL) because the reference doc was ambiguous. LLMs now reason from `ModelName` directly.
2. **Batched icon creation** — new `create_icons()` method + `icons: [...]` array parameter on `streamdeck_create_icon`. 32-key XL decks authored with serial calls timed out; batched calls complete in a fraction of the time. Per-spec errors don't abort the batch.
3. **Stringified-argument coercion** — Claude Code's JSON-RPC tool-call transport stringifies every non-string MCP parameter (arrays, numbers, booleans, integers). Every typed tool-schema field now uses `oneOf [native, string]` and a new `_coerce_arguments()` normalizer unwraps back to native types before dispatch. Unparseable strings pass through to downstream handler error messages. This unblocks 30-icon batch writes and `auto_quit_app: true` calls from any Claude Code session.
4. **Added "AI Stream Deck" to `MODEL_LAYOUTS`** — Elgato renamed the virtual companion emulator in recent builds.

### On-device verification

Ran the full authoring flow twice against Jack's Plus XL:
- First pass on Cursor profile: 14-button Ember-themed Home Assistant heating deck. Landed on the default page; visibility confirmed after profile navigation.
- Second pass on a dedicated "Testing" profile: same 14 buttons written to the current page, Elgato app relaunched, Jack confirmed **the buttons fire on physical press**. End-to-end HA state change verified (`input_boolean.night_mode` flipped off→on via the generated shell script).

The first trial with Steve surfaced the stringification bug class; this PR fixes all four observed classes (arrays, numbers, booleans, integers) with schemas + a coercion layer.

### Pre-PR code review

Ran a code-reviewer pass before opening this PR. Findings addressed in commit `cf922c4`:

- Empty-string bool coercion (`""` no longer silently treated as False — passes through to handler default).
- `install_skill --force` is destructive and now says so in help text + return flag.
- Stringified-but-unparseable `buttons` now gets a clear error message instead of iterating the string one char at a time.

Nits deferred to follow-ups:
- `MODEL_NAMES`/`MODEL_LAYOUTS` drift risk (two parallel dicts keyed by product ID) — would benefit from a unit test asserting key parity.
- Dated staleness marker on `sdk-urls.md`.
- Log breadcrumb when `design_streamdeck_deck` prompt can't find SKILL.md.

## Commits

- `9c88805` feat(skill): ship streamdeck-designer Agent Skill for one-shot deck authoring
- `f20dc03` feat(skill): round 2 fixes from Steve's first trial run
- `6d39acf` fix(server): accept stringified tool-call args from Claude Code transport
- `caeb9d7` docs(skill): add SDK primer + URL index for authoritative lookup
- `cf922c4` fix(server,skill-install): address pre-PR review findings

## Test plan

- [x] `uv run pytest tests/` — 81 passed (10 new: batch icons, ModelName enrichment, stringified-arg coercion, overwrite install signal, empty-string bool passthrough).
- [x] `uv run ruff check .` — clean.
- [x] Skill scaffolds install via `streamdeck-mcp-install-skill`.
- [x] `design_streamdeck_deck` MCP prompt registers and returns the SKILL.md body.
- [x] On-device: 14-button heating deck on Plus XL Testing profile, buttons fire on press, HA state changes confirmed end-to-end.
- [ ] Marketplace sdist/wheel sanity check post-release (release-please will bump the version on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)