### PR TITLE
fix(macos): scope the app-running check and killall to the current user

### DIFF
--- a/profile_manager.py
+++ b/profile_manager.py
@@ -466,9 +466,14 @@ def is_stream_deck_app_running() -> bool:
     if sys.platform != "darwin":
         return False
 
+    # Scope to the current user: on a Mac with several logins (fast user
+    # switching) each login runs its own copy of the app against its own
+    # ProfilesV3. Another user's instance cannot overwrite our profiles, and
+    # we cannot quit it, so it must not count as "running".
+    uid = str(os.getuid())
     for name in STREAM_DECK_APP_PROCESS_NAMES:
         result = subprocess.run(
-            ["pgrep", "-x", name],
+            ["pgrep", "-x", "-u", uid, name],
             capture_output=True,
             text=True,
             check=False,
@@ -511,7 +516,7 @@ def stop_stream_deck_app(*, graceful_timeout: float = 3.0) -> dict[str, Any]:
     if is_stream_deck_app_running():
         for name in STREAM_DECK_APP_PROCESS_NAMES:
             result = subprocess.run(
-                ["killall", name],
+                ["killall", "-u", str(os.getuid()), name],
                 capture_output=True,
                 text=True,
                 check=False,

--- a/tests/test_profile_manager.py
+++ b/tests/test_profile_manager.py
@@ -4,6 +4,8 @@ Tests for the Stream Deck desktop profile manager.
 
 import json
 import shlex
+import subprocess
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,6 +17,7 @@ from profile_manager import (
     ProfileManagerError,
     ProfileValidationError,
     StreamDeckAppRunningError,
+    is_stream_deck_app_running,
 )
 
 
@@ -2324,3 +2327,31 @@ def test_install_skill_marks_overwrote_when_target_exists(tmp_path) -> None:
         install_skill.SKILLS_ROOT = original_skills_root
         if target_parent.exists():
             shutil.rmtree(target_parent)
+
+
+def test_is_stream_deck_app_running_scopes_pgrep_to_current_user() -> None:
+    """Another macOS login's Stream Deck instance must not count as running."""
+    import os
+
+    import profile_manager
+
+    # `is_stream_deck_app_running` here is the real function, bound at import
+    # time before the autouse fixture replaced the module attribute.
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, returncode=1, stdout="", stderr="")
+
+    with (
+        patch.object(profile_manager.sys, "platform", "darwin"),
+        patch("profile_manager.subprocess.run", side_effect=fake_run),
+    ):
+        assert is_stream_deck_app_running() is False
+
+    assert calls, "expected pgrep to be invoked"
+    for cmd in calls:
+        assert cmd[0] == "pgrep"
+        assert "-u" in cmd
+        assert cmd[cmd.index("-u") + 1] == str(os.getuid())


### PR DESCRIPTION
## Problem

On a Mac with more than one login signed in (fast user switching), each login runs its own copy of the Elgato app against its own `ProfilesV3`. `is_stream_deck_app_running()` uses `pgrep -x "Stream Deck"`, which matches every user's instance. So a `streamdeck_write_page` with `auto_quit_app=True` from user A fails with *"The Elgato Stream Deck app could not be stopped"* whenever user B's app is up: the AppleScript quit and `killall` only reach A's own process, B's keeps running, and the check never clears.

B's instance cannot overwrite A's profiles (different home directory), so it should not count.

## Fix

Pass `-u <uid>` to both `pgrep` and `killall` so only the caller's own instance is detected or stopped. `os.getuid()` is used rather than `$USER` so it holds under `sudo -u` and launchd.

## Test

Adds a test asserting the `pgrep` invocation carries `-u <current uid>`. The real function is bound at import time so the autouse fixture that mocks `is_stream_deck_app_running` does not short-circuit it. Full suite passes.

Reproduced on macOS 26 with two console logins and a Stream Deck +.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016A7CesoQLJuJqDtb4benvw
